### PR TITLE
HTTP client: update to handle RFC standard cookies

### DIFF
--- a/src/main/java/com/wavesplatform/wavesj/Node.java
+++ b/src/main/java/com/wavesplatform/wavesj/Node.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -29,7 +31,10 @@ public class Node {
     private static final TypeReference<List<Order>> ORDER_LIST = new TypeReference<List<Order>>() {};
 
     private final URI uri;
-    private final CloseableHttpClient client = HttpClients.createDefault();
+    private final CloseableHttpClient client = HttpClients.custom()
+            .setDefaultRequestConfig(RequestConfig.custom()
+                    .setCookieSpec(CookieSpecs.STANDARD).build())
+            .build();
 
     public Node() {
         try {


### PR DESCRIPTION
Preventing the "invalid expires attribute" warning. See https://stackoverflow.com/questions/36473478/fixing-httpclient-warning-invalid-expires-attribute-using-fluent-api.