### PR TITLE
fix java.lang.IllegalArgumentException: TransactionWithBytesHashId.getId

### DIFF
--- a/src/main/java/com/wavesplatform/wavesj/ByteUtils.java
+++ b/src/main/java/com/wavesplatform/wavesj/ByteUtils.java
@@ -42,6 +42,8 @@ public class ByteUtils {
     }
 
     public static String putRecipient(ByteBuffer buffer, byte chainId, String recipient) {
+        // recipient 3PHnZyXiQp45kU5TvYVPU6YmLmwUqJWYwvj / alias:W:vpb9ia5xhcgwespwp8nreigxx3w3oq
+        recipient = recipient.startsWith(Alias.PREFIX) && recipient.charAt(7) == ':' ? recipient.substring(8) : recipient;
         if (recipient.length() <= 30) {
             // assume an alias
             buffer.put((byte) 0x02).put(chainId).putShort((short) recipient.length()).put(recipient.getBytes(UTF8));


### PR DESCRIPTION
mainnet
at block 1477795
``` java
java.lang.IllegalArgumentException: Illegal character l at position 1

	at com.wavesplatform.wavesj.Base58.decode(Base58.java:94)
	at com.wavesplatform.wavesj.ByteUtils.putRecipient(ByteUtils.java:50)
	at com.wavesplatform.wavesj.transactions.TransferTransactionV2.getBytes(TransferTransactionV2.java:103)
	at com.wavesplatform.wavesj.transactions.TransactionWithBytesHashId.getId(TransactionWithBytesHashId.java:10)
...
```