### PR TITLE
Migrate invocation transaction to 0.17.2 Node version

### DIFF
--- a/src/main/java/com/wavesplatform/wavesj/ByteUtils.java
+++ b/src/main/java/com/wavesplatform/wavesj/ByteUtils.java
@@ -1,5 +1,6 @@
 package com.wavesplatform.wavesj;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.text.MessageFormat;
@@ -8,6 +9,9 @@ import static com.wavesplatform.wavesj.Asset.isWaves;
 
 public class ByteUtils {
     public static final int KBYTE = 1024;
+    public static final byte OPTIONAL_EXIST = 1;
+    public static final byte OPTIONAL_EMPTY = 0;
+
     public final static Charset UTF8 = Charset.forName("UTF-8");
 
     private static final String LENGTH_GT_SHORT = "Attempting to put array with size={0} greater than MaxShort({1})";
@@ -19,11 +23,19 @@ public class ByteUtils {
         return bytes;
     }
 
+    public static void putOptionalFlag(ByteBuffer buffer, Serializable obj) {
+        if (obj != null) {
+            buffer.put(ByteUtils.OPTIONAL_EXIST);
+        } else {
+            buffer.put(ByteUtils.OPTIONAL_EMPTY);
+        }
+    }
+
     public static void putAsset(ByteBuffer buffer, String assetId) {
         if (isWaves(assetId)) {
-            buffer.put((byte) 0);
+            buffer.put(OPTIONAL_EMPTY);
         } else {
-            buffer.put((byte) 1).put(Base58.decode(assetId));
+            buffer.put(OPTIONAL_EXIST).put(Base58.decode(assetId));
         }
     }
 

--- a/src/main/java/com/wavesplatform/wavesj/transactions/ContractInvocationTransaction.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/ContractInvocationTransaction.java
@@ -22,7 +22,7 @@ public class ContractInvocationTransaction extends TransactionWithProofs {
 
     private byte chainId;
     private PublicKeyAccount senderPublicKey;
-    private @JsonProperty("dappAddress") String recipient;
+    private @JsonProperty("dApp") String recipient;
     private FunctionCall call;
     private @JsonProperty("payment") List<Payment> payments = new ArrayList<Payment>();
     private long fee;
@@ -44,7 +44,7 @@ public class ContractInvocationTransaction extends TransactionWithProofs {
         this.senderPublicKey = senderPublicKey;
         this.recipient = recipient;
         this.call = call;
-        this.payments = payments;
+        this.payments = payments != null ? payments : new ArrayList<Payment>();
         this.fee = fee;
         this.feeAssetId = feeAssetId;
         this.timestamp = timestamp;
@@ -55,7 +55,9 @@ public class ContractInvocationTransaction extends TransactionWithProofs {
         this.chainId = chainId;
         this.senderPublicKey = senderPublicKey;
         this.recipient = recipient;
-        this.call = new FunctionCall(function);
+        if (function != null) {
+            this.call = new FunctionCall(function);
+        }
         this.fee = fee;
         this.feeAssetId = feeAssetId;
         this.timestamp = timestamp;
@@ -143,7 +145,10 @@ public class ContractInvocationTransaction extends TransactionWithProofs {
         buf.put(senderPublicKey.getPublicKey());
         ByteUtils.putRecipient(buf, chainId, recipient);
 
-        call.write(buf);
+        ByteUtils.putOptionalFlag(buf, call);
+        if (call != null) {
+            call.write(buf);
+        }
 
         buf.putShort(toShort(payments.size()));
         for (Payment payment: payments) {
@@ -169,7 +174,7 @@ public class ContractInvocationTransaction extends TransactionWithProofs {
         if (getTimestamp() != that.getTimestamp()) return false;
         if (!getSenderPublicKey().equals(that.getSenderPublicKey())) return false;
         if (!getRecipient().equals(that.getRecipient())) return false;
-        if (!getCall().equals(that.getCall())) return false;
+        if (getCall() != null ? !getCall().equals(that.getCall()) : that.getCall() != null) return false;
         if (getPayments() != null ? !getPayments().equals(that.getPayments()) : that.getPayments() != null)
             return false;
         return getFeeAssetId() != null ? getFeeAssetId().equals(that.getFeeAssetId()) : that.getFeeAssetId() == null;
@@ -180,7 +185,7 @@ public class ContractInvocationTransaction extends TransactionWithProofs {
         int result = (int) getChainId();
         result = 31 * result + getSenderPublicKey().hashCode();
         result = 31 * result + getRecipient().hashCode();
-        result = 31 * result + getCall().hashCode();
+        result = 31 * result + (getCall() != null ? getCall().hashCode() : 0);
         result = 31 * result + (getPayments() != null ? getPayments().hashCode() : 0);
         result = 31 * result + (int) (getFee() ^ (getFee() >>> 32));
         result = 31 * result + (getFeeAssetId() != null ? getFeeAssetId().hashCode() : 0);

--- a/src/test/java/com/wavesplatform/wavesj/ContractInvocationITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/ContractInvocationITest.java
@@ -91,9 +91,20 @@ public class ContractInvocationITest extends BaseITest {
         stageDone("#02", "invoke deposit function without args (invest 2 Waves)");
     }
 
+    /**
+     * Invest 2 Waves - call default function
+     */
+    @Test
+    public void t015_invokeDefaultFunc() throws Exception {
+        stageStart("#03", "invoke @Default function (invest 2 Waves)");
+        ContractInvocationTransaction defaultInv = createInvoke(INV_DEFAULT_FUNC, toWavelets(0.005), INV_DEFAULT_PAYMENT);
+        sendInv(defaultInv);
+        stageDone("#03", "invoke @Default function (invest 2 Waves)");
+    }
+
     @Test
     public void t020_invokeFuncWithAllTypesOfArgs() throws Exception {
-        stageStart("#03", "invoke withdraw with all types of args");
+        stageStart("#04", "invoke withdraw with all types of args");
         ContractInvocationTransaction withdrawTx = createInvoke(INV2_FUNC, toWavelets(0.005), 0);
         withdrawTx = withdrawTx
                 .withArg(INV2_ARG1)
@@ -102,7 +113,7 @@ public class ContractInvocationITest extends BaseITest {
                 .withArg(INV2_ARG4)
                 .sign(investorAcc);
         inv2Id = sendInv(withdrawTx);
-        stageDone("#03", "invoke withdraw with all types of args");
+        stageDone("#04", "invoke withdraw with all types of args");
     }
 
     @Test

--- a/src/test/java/com/wavesplatform/wavesj/json/ContractInvocationTxTestData.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/ContractInvocationTxTestData.java
@@ -1,0 +1,165 @@
+package com.wavesplatform.wavesj.json;
+
+import com.wavesplatform.wavesj.ByteString;
+import com.wavesplatform.wavesj.PublicKeyAccount;
+import com.wavesplatform.wavesj.json.ser.TransactionSerTest;
+import com.wavesplatform.wavesj.transactions.ContractInvocationTransaction;
+
+import static com.wavesplatform.wavesj.Asset.toWavelets;
+import static java.util.Collections.singletonList;
+
+/**
+ * Account 1 (sender):
+ *      address=3MtEyGGB3XQ6zWB71cCN98fotHvjxxwNMu4
+ *      public=4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce
+ *      private=3C8rjfZJnh2EHhKccvggPsoMXLw53DriT8EnjyRPJdhh
+ *      seed=sunset noodle trap mule mango can spring garment slot august photo champion paper host more
+ *
+ * Account 2 (recipient):
+ *      address=3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw
+ *      public=H9S6sPxueb6z1PB46VZJD6FbaTxsNfT8GHv5PPHbvDHx
+ *      private=HAWqLZA98pJPvwGZuomKUkNpgfzKt4HhfMdFWPXwjxuX
+ *      seed=creek extend car eight fat hole farm they behave element bag allow absurd clinic harbor
+ */
+public final class ContractInvocationTxTestData {
+    private static final byte chainId = TransactionSerTest.chainId;
+
+    public static final PublicKeyAccount SENDER_PUB =
+            new PublicKeyAccount("4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce", chainId);
+
+    public static final PublicKeyAccount RECIPIENT_PUB =
+            new PublicKeyAccount("H9S6sPxueb6z1PB46VZJD6FbaTxsNfT8GHv5PPHbvDHx", chainId);
+
+    public static ContractInvocationTransaction txFull() {
+        return new ContractInvocationTransaction(
+                chainId,
+                SENDER_PUB,
+                RECIPIENT_PUB.getAddress(),
+                new ContractInvocationTransaction.FunctionCall("deposit")
+                        .addArg(10L)
+                        .addArg("STRING_ARG")
+                        .addArg(true)
+                        .addArg(new ByteString("4QZkF9")),
+                singletonList(new ContractInvocationTransaction.Payment(toWavelets(10), null)),
+                toWavelets(0.005),
+                null,
+                1526983936610L,
+                singletonList(new ByteString("59e1LnALZD7JssScwso6Rj9geZvUvRYEgDQe3xb312gKEqHQRMewgFJsAdcGcCAUhQPwpt5yfA7i42kdukwQNEJg"))
+        );
+    }
+
+    public static String txFullJson() {
+        return "{\"chainId\":84," +
+                "\"senderPublicKey\":\"4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce\"," +
+                "\"dApp\":\"3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw\"," +
+                "\"call\":{" +
+                    "\"function\":\"deposit\"," +
+                    "\"args\":[" +
+                        "{\"value\":10,\"type\":\"integer\"}," +
+                        "{\"value\":\"STRING_ARG\",\"type\":\"string\"}," +
+                        "{\"value\":true,\"type\":\"boolean\"}," +
+                        "{\"value\":\"base64:hUKqkA==\",\"type\":\"binary\"}" +
+                "]}," +
+                "\"payment\":[{\"amount\":1000000000,\"assetId\":null}]," +
+                "\"fee\":500000," +
+                "\"feeAssetId\":null," +
+                "\"timestamp\":1526983936610," +
+                "\"proofs\":[\"59e1LnALZD7JssScwso6Rj9geZvUvRYEgDQe3xb312gKEqHQRMewgFJsAdcGcCAUhQPwpt5yfA7i42kdukwQNEJg\"]," +
+                "\"type\":16," +
+                "\"version\":1," +
+                "\"height\":1234}";
+    }
+
+    public static ContractInvocationTransaction txNoFunctionCall() {
+        return new ContractInvocationTransaction(
+                chainId,
+                SENDER_PUB,
+                RECIPIENT_PUB.getAddress(),
+                null,
+                singletonList(new ContractInvocationTransaction.Payment(toWavelets(10), null)),
+                toWavelets(0.005),
+                null,
+                1526983936610L,
+                singletonList(new ByteString("2BaoLeTH3CXiwvQHdmuwEUNQsPtAHrrZv2fWxEsWh4TJyhJvRs27VVusEzpaCiW1oX9eY6eB57qUiSsw2GaJpF8w"))
+        );
+    }
+
+    public static String txNoFunctionCallJson() {
+        return "{\"chainId\":84," +
+                "\"dApp\":\"3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw\",\n" +
+                "\"senderPublicKey\":\"4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce\"," +
+                "\"payment\":[{\"amount\":1000000000,\"assetId\":null}]," +
+                "\"fee\":500000," +
+                "\"feeAssetId\":null," +
+                "\"timestamp\":1526983936610," +
+                "\"proofs\":[\"2BaoLeTH3CXiwvQHdmuwEUNQsPtAHrrZv2fWxEsWh4TJyhJvRs27VVusEzpaCiW1oX9eY6eB57qUiSsw2GaJpF8w\"]," +
+                "\"type\":16," +
+                "\"version\":1," +
+                "\"height\":\"1234\"}";
+    }
+
+    public static ContractInvocationTransaction txNoPayment() {
+        return new ContractInvocationTransaction(
+                chainId,
+                SENDER_PUB,
+                RECIPIENT_PUB.getAddress(),
+                new ContractInvocationTransaction.FunctionCall("deposit")
+                        .addArg(10L)
+                        .addArg("STRING_ARG")
+                        .addArg(true)
+                        .addArg(new ByteString("4QZkF9")),
+                null,
+                toWavelets(0.005),
+                null,
+                1526983936610L,
+                singletonList(new ByteString("4JFJ2w7qqVaD4npGobojPHQ7fwAXw2q4fJDYTjJsqUQT9ZRKuDr5doWgGuR2o1skbeUzLhxaNKEiqv7KHvh5pJyT"))
+        );
+    }
+
+    public static String txNoPaymentJson() {
+        return "{\"chainId\":84," +
+                "\"dApp\":\"3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw\"," +
+                "\"senderPublicKey\":\"4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce\"," +
+                "\"call\":{" +
+                    "\"function\":\"deposit\"," +
+                    "\"args\":[" +
+                        "{\"value\":10,\"type\":\"integer\"}," +
+                        "{\"value\":\"STRING_ARG\",\"type\":\"string\"}," +
+                        "{\"value\":true,\"type\":\"boolean\"}," +
+                        "{\"value\":\"base64:hUKqkA==\",\"type\":\"binary\"}]}," +
+                "\"fee\":500000," +
+                "\"feeAssetId\":null," +
+                "\"timestamp\":1526983936610," +
+                "\"proofs\":[\"4JFJ2w7qqVaD4npGobojPHQ7fwAXw2q4fJDYTjJsqUQT9ZRKuDr5doWgGuR2o1skbeUzLhxaNKEiqv7KHvh5pJyT\"]," +
+                "\"type\":16," +
+                "\"version\":1," +
+                "\"height\":1234}";
+    }
+
+    public static ContractInvocationTransaction txNoFunctionCallAndPayment() {
+        return new ContractInvocationTransaction(
+                chainId,
+                SENDER_PUB,
+                RECIPIENT_PUB.getAddress(),
+                null,
+                null,
+                toWavelets(0.005),
+                null,
+                1526983936610L,
+                singletonList(new ByteString("FSCsS76cewPEcYidPe8wffaiPPE3kPfvnPRupgsDw3v7QNuEBmZY24kgvm2ar5CQDmVovdGFLyUFZZWs1PbEPgv"))
+        );
+    }
+
+    public static String txNoFunctionCallAndPaymentJson() {
+        return "{\"chainId\":84," +
+                "\"dApp\":\"3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw\"," +
+                "\"senderPublicKey\":\"4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce\"," +
+                "\"fee\":500000," +
+                "\"feeAssetId\":null," +
+                "\"timestamp\":1526983936610," +
+                "\"proofs\":[\"FSCsS76cewPEcYidPe8wffaiPPE3kPfvnPRupgsDw3v7QNuEBmZY24kgvm2ar5CQDmVovdGFLyUFZZWs1PbEPgv\"]," +
+                "\"type\":16," +
+                "\"version\":1," +
+                "\"height\":1234}";
+    }
+}

--- a/src/test/java/com/wavesplatform/wavesj/json/deser/ContractInvocationTransactionDeserTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/deser/ContractInvocationTransactionDeserTest.java
@@ -1,54 +1,42 @@
 package com.wavesplatform.wavesj.json.deser;
 
-import com.wavesplatform.wavesj.Account;
-import com.wavesplatform.wavesj.ByteString;
-import com.wavesplatform.wavesj.PublicKeyAccount;
+import com.wavesplatform.wavesj.json.ContractInvocationTxTestData;
 import com.wavesplatform.wavesj.transactions.ContractInvocationTransaction;
 import org.junit.Test;
 
 import java.io.IOException;
 
-import static com.wavesplatform.wavesj.Asset.toWavelets;
-import static java.util.Collections.singletonList;
-
 public class ContractInvocationTransactionDeserTest extends TransactionDeserTest {
-
-    private ContractInvocationTransaction tx = new ContractInvocationTransaction(
-            Account.TESTNET,
-            new PublicKeyAccount("4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce", Account.TESTNET),
-            "3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw",
-            new ContractInvocationTransaction.FunctionCall("deposit")
-                    .addArg(10L)
-                    .addArg("STRING_ARG")
-                    .addArg(true)
-                    .addArg(new ByteString("4QZkF9")),
-            singletonList(new ContractInvocationTransaction.Payment(toWavelets(10), null)),
-            toWavelets(0.005),
-            null,
-            1526983936610L,
-            singletonList(new ByteString("59e1LnALZD7JssScwso6Rj9geZvUvRYEgDQe3xb312gKEqHQRMewgFJsAdcGcCAUhQPwpt5yfA7i42kdukwQNEJg"))
-    );
 
     @Test
     public void V1DeserializeTest() throws IOException {
-        deserializationTest("{\"chainId\":84," +
-                "\"senderPublicKey\":\"4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce\"," +
-                "\"dappAddress\":\"3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw\"," +
-                "\"call\":{" +
-                    "\"function\":\"deposit\"," +
-                    "\"args\":[" +
-                        "{\"value\":10,\"type\":\"integer\"}," +
-                        "{\"value\":\"STRING_ARG\",\"type\":\"string\"}," +
-                        "{\"value\":true,\"type\":\"boolean\"}," +
-                        "{\"type\":\"binary\",\"value\":\"base64:hUKqkA==\"}" +
-                    "]}," +
-                "\"payment\":[{\"amount\":1000000000,\"assetId\":null}]," +
-                "\"fee\":500000," +
-                "\"feeAssetId\":null," +
-                "\"timestamp\":1526983936610," +
-                "\"proofs\":[\"59e1LnALZD7JssScwso6Rj9geZvUvRYEgDQe3xb312gKEqHQRMewgFJsAdcGcCAUhQPwpt5yfA7i42kdukwQNEJg\"]," +
-                "\"type\":16," +
-                "\"version\":1," +
-                "\"height\":1234}", tx, ContractInvocationTransaction.class);
+        deserializationTest(
+                ContractInvocationTxTestData.txFullJson(),
+                ContractInvocationTxTestData.txFull(),
+                ContractInvocationTransaction.class);
+    }
+
+    @Test
+    public void testV1DeserTxNoFunctionCall() throws IOException {
+        deserializationTest(
+                ContractInvocationTxTestData.txNoFunctionCallJson(),
+                ContractInvocationTxTestData.txNoFunctionCall(),
+                ContractInvocationTransaction.class);
+    }
+
+    @Test
+    public void testV1DeserTxNoPayment() throws IOException {
+        deserializationTest(
+                ContractInvocationTxTestData.txNoPaymentJson(),
+                ContractInvocationTxTestData.txNoPayment(),
+                ContractInvocationTransaction.class);
+    }
+
+    @Test
+    public void testV1DeserTxNoFunctionCallAndPayment() throws IOException {
+        deserializationTest(
+                ContractInvocationTxTestData.txNoFunctionCallAndPaymentJson(),
+                ContractInvocationTxTestData.txNoFunctionCallAndPayment(),
+                ContractInvocationTransaction.class);
     }
 }

--- a/src/test/java/com/wavesplatform/wavesj/json/ser/ContractInvocationTransactionSerTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/ser/ContractInvocationTransactionSerTest.java
@@ -1,48 +1,38 @@
 package com.wavesplatform.wavesj.json.ser;
 
-import com.wavesplatform.wavesj.*;
+import com.wavesplatform.wavesj.json.ContractInvocationTxTestData;
 import com.wavesplatform.wavesj.transactions.ContractInvocationTransaction;
-import com.wavesplatform.wavesj.transactions.ContractInvocationTransaction.FunctionCall;
-import com.wavesplatform.wavesj.transactions.ContractInvocationTransaction.Payment;
 import org.junit.Test;
 
 import java.io.IOException;
-import static com.wavesplatform.wavesj.Asset.toWavelets;
-import static java.util.Collections.singletonList;
 
-/**
- * Account 1:
- *      address=3MtEyGGB3XQ6zWB71cCN98fotHvjxxwNMu4
- *      public=4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce
- *      private=3C8rjfZJnh2EHhKccvggPsoMXLw53DriT8EnjyRPJdhh
- *      seed=sunset noodle trap mule mango can spring garment slot august photo champion paper host more
- *
- * Account 2:
- *      address=3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw
- *      public=H9S6sPxueb6z1PB46VZJD6FbaTxsNfT8GHv5PPHbvDHx
- *      private=HAWqLZA98pJPvwGZuomKUkNpgfzKt4HhfMdFWPXwjxuX
- *      seed=creek extend car eight fat hole farm they behave element bag allow absurd clinic harbor
- */
 public class ContractInvocationTransactionSerTest extends TransactionSerTest {
 
-    ContractInvocationTransaction tx = new ContractInvocationTransaction(
-            Account.TESTNET,
-                new PublicKeyAccount("4QZkF9ejEsao1M8pNDAjoNqGsLsT3E6koXbNtCFxscce", Account.TESTNET),
-                "3Mvqinkpz45gprXcpgcMb9yqUv4jpBGMQMw",
-                        new FunctionCall("deposit")
-                        .addArg(10L)
-                        .addArg("STRING_ARG")
-                        .addArg(true)
-                        .addArg(new ByteString("4QZkF9")),
-                singletonList(new Payment(toWavelets(10), null)),
-                toWavelets(0.005),
-                null,
-                1526983936610L,
-                singletonList(new ByteString("59e1LnALZD7JssScwso6Rj9geZvUvRYEgDQe3xb312gKEqHQRMewgFJsAdcGcCAUhQPwpt5yfA7i42kdukwQNEJg"))
-            );
+    @Test
+    public void testV1SerTxFull() throws IOException {
+        serializationRoadtripTest(
+                ContractInvocationTxTestData.txFull(),
+                ContractInvocationTransaction.class);
+    }
 
     @Test
-    public void V1SerializationTest() throws IOException {
-        serializationRoadtripTest(tx, ContractInvocationTransaction.class);
+    public void testV1SerTxNoFunctionalCall() throws IOException {
+        serializationRoadtripTest(
+                ContractInvocationTxTestData.txNoFunctionCall(),
+                ContractInvocationTransaction.class);
+    }
+
+    @Test
+    public void testV1SerTxNoPayment() throws IOException {
+        serializationRoadtripTest(
+                ContractInvocationTxTestData.txNoPayment(),
+                ContractInvocationTransaction.class);
+    }
+
+    @Test
+    public void testV1SerTxNoFunctionalCallAndPayment() throws IOException {
+        serializationRoadtripTest(
+                ContractInvocationTxTestData.txNoFunctionCallAndPayment(),
+                ContractInvocationTransaction.class);
     }
 }

--- a/src/test/java/com/wavesplatform/wavesj/json/ser/TransactionSerTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/ser/TransactionSerTest.java
@@ -1,6 +1,7 @@
 package com.wavesplatform.wavesj.json.ser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wavesplatform.wavesj.Account;
 import com.wavesplatform.wavesj.Transaction;
 import com.wavesplatform.wavesj.json.WavesJsonMapper;
 
@@ -10,7 +11,9 @@ import java.io.StringWriter;
 import static org.junit.Assert.assertEquals;
 
 public abstract class TransactionSerTest {
-    ObjectMapper mapper = new WavesJsonMapper((byte) 'T');
+
+    public static final byte chainId = Account.TESTNET;
+    static final ObjectMapper mapper = new WavesJsonMapper(chainId);
 
     protected <T extends Transaction> T serializationRoadtripTest(T tx, Class<T> txClass) throws IOException {
         StringWriter sw = new StringWriter();
@@ -18,6 +21,7 @@ public abstract class TransactionSerTest {
         T deserialized = mapper.readValue(sw.toString(), txClass);
         assertEquals(deserialized, tx);
         assertEquals(deserialized.getId(), tx.getId());
+        // height is not tracked during serialization
         assertEquals(0, deserialized.getHeight());
         return deserialized;
     }

--- a/src/test/resources/ride4dapp/wallet.ride
+++ b/src/test/resources/ride4dapp/wallet.ride
@@ -2,20 +2,28 @@
 {-# CONTENT_TYPE DAPP #-}
 {-# SCRIPT_TYPE ACCOUNT #-}
 
-@Callable(i)
-func deposit() = {
-    let pmt = extract(i.payment)
+func depositImpl(pmt:AttachedPayment, caller:Address) = {
     if (isDefined(pmt.assetId))
         then throw("can hodl waves only at the moment")
     else {
-        let currentKey = toBase58String(i.caller.bytes)
+        let currentKey = toBase58String(caller.bytes)
         let currentAmount = match getInteger(this, currentKey) {
             case a:Int => a
             case _ => 0
         }
         let newAmount = currentAmount + pmt.amount
         WriteSet([DataEntry(currentKey, newAmount)])
-   }
+    }
+}
+
+@Default(i)
+func defaultDeposit() = {
+    depositImpl(extract(i.payment), i.caller)
+}
+
+@Callable(i)
+func deposit() = {
+    depositImpl(extract(i.payment), i.caller)
 }
 
 @Callable(i)


### PR DESCRIPTION
Migrate invocation transaction.
In [0.17.2 Node Release](https://forum.wavesplatform.com/t/node-0-17-2-on-testnet/14398) the following changes were done:
- serialization of InvokeScriptTransaction
- signature bytes
- functional call can be optional (@Default method)