### PR TITLE
double precision in toWavelets() bugfix

### DIFF
--- a/src/main/java/com/wavesplatform/wavesj/Asset.java
+++ b/src/main/java/com/wavesplatform/wavesj/Asset.java
@@ -1,6 +1,7 @@
 package com.wavesplatform.wavesj;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 
 public abstract class Asset {
@@ -18,7 +19,7 @@ public abstract class Asset {
     public static final int DEFAULT_SCALE = 12;
 
     public static long toWavelets(double amount) {
-        return (long) (amount * TOKEN);
+        return (WAVELETS_MULT.multiply(new BigDecimal(amount, MathContext.DECIMAL64))).longValue();
     }
 
     public static long toWavelets(long amount) {


### PR DESCRIPTION
If you pass something like 0.0003 as a parameter to method toWavelets(**double** amount), you'll get 29999 in output (see: https://stackoverflow.com/a/322875)
This commit fixes that behavior.