### PR TITLE
Support state changes endpoints in Node client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -137,21 +137,13 @@
                 </executions>
             </plugin>
         </plugins>
-
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.0</version>
-            </extension>
-        </extensions>
     </build>
 
     <dependencies>
         <dependency>
             <groupId>com.wavesplatform</groupId>
             <artifactId>protobuf-schemas</artifactId>
-            <version>1.0.0</version>
+            <version>1.2.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.whispersystems</groupId>
@@ -204,12 +196,6 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>1.20.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.wavesplatform</groupId>
-            <artifactId>protobuf-schemas</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,12 @@
         <dependency>
             <groupId>com.wavesplatform</groupId>
             <artifactId>protobuf-schemas</artifactId>
-            <version>1.2.6-SNAPSHOT</version>
+            <version>1.2.6</version>
+        </dependency>
+        <dependency> <!-- todo remove after com.wavesplatform.protobuf-schemas 1.2.7 -->
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.12.2</version>
         </dependency>
         <dependency>
             <groupId>org.whispersystems</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
@@ -204,6 +204,12 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>1.20.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.wavesplatform</groupId>
+            <artifactId>protobuf-schemas</artifactId>
+            <version>1.2.6-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/wavesplatform/wavesj/AllTxIterator.java
+++ b/src/main/java/com/wavesplatform/wavesj/AllTxIterator.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-public class AllTxIterator implements Iterator<Transaction> {
+public class AllTxIterator<T extends Transaction> implements Iterator<T>  {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("com.wavesplatform.wavesj");
 
@@ -17,10 +17,10 @@ public class AllTxIterator implements Iterator<Transaction> {
     private boolean hasNext;
     private Transaction lastSuccessNext;
     private String address;
-    private Iterator<? extends Transaction> dataIt;
-    private TransactionsLazyLoader<List<? extends Transaction>> txSupplier;
+    private Iterator<T> dataIt;
+    private TransactionsLazyLoader<List<T>> txSupplier;
 
-    public AllTxIterator(String address, int pageSize, TransactionsLazyLoader<List<? extends Transaction>> txSupplier) {
+    public AllTxIterator(String address, int pageSize, TransactionsLazyLoader<List<T>> txSupplier) {
         this.address = address;
         this.pageSize = pageSize;
         this.txSupplier = txSupplier;
@@ -33,7 +33,7 @@ public class AllTxIterator implements Iterator<Transaction> {
             String lastId = lastSuccessNext != null ? lastSuccessNext.getId().getBase58String() : null;
             LOGGER.debug("Dynamic load for remaining transactions: address={} page_size={} after_tx={}",
                     address, pageSize, lastId);
-            List<? extends Transaction> txs = txSupplier.load(address, pageSize, lastId);
+            List<T> txs = txSupplier.load(address, pageSize, lastId);
             LOGGER.debug("Dynamic load for remaining transactions: loaded={}", txs.size());
             dataIt = txs.iterator();
             dataSize = txs.size();
@@ -49,8 +49,8 @@ public class AllTxIterator implements Iterator<Transaction> {
     }
 
     @Override
-    public Transaction next() {
-        Transaction next;
+    public T next() {
+        T next;
         if (hasNext) {
             next = dataIt.next();
             lastSuccessNext = next;

--- a/src/main/java/com/wavesplatform/wavesj/AllTxIterator.java
+++ b/src/main/java/com/wavesplatform/wavesj/AllTxIterator.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-public class AllTxIterator<T extends Transaction> implements Iterator<T>  {
+public class AllTxIterator<T extends Transaction> implements Iterator<T>, Iterable<T>  {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("com.wavesplatform.wavesj");
 
@@ -68,6 +68,11 @@ public class AllTxIterator<T extends Transaction> implements Iterator<T>  {
     @Override
     public void remove() {
         throw new UnsupportedOperationException("remove");
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return this;
     }
 
     public interface TransactionsLazyLoader<T> {

--- a/src/main/java/com/wavesplatform/wavesj/AllTxIterator.java
+++ b/src/main/java/com/wavesplatform/wavesj/AllTxIterator.java
@@ -1,0 +1,88 @@
+package com.wavesplatform.wavesj;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class AllTxIterator implements Iterator<Transaction> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("com.wavesplatform.wavesj");
+
+    private int dataSize;
+    private int pageSize;
+    private boolean hasNext;
+    private Transaction lastSuccessNext;
+    private String address;
+    private Iterator<? extends Transaction> dataIt;
+    private TransactionsLazyLoader<List<? extends Transaction>> txSupplier;
+
+    public AllTxIterator(String address, int pageSize, TransactionsLazyLoader<List<? extends Transaction>> txSupplier) {
+        this.address = address;
+        this.pageSize = pageSize;
+        this.txSupplier = txSupplier;
+        this.lastSuccessNext = null;
+        fetchNext();
+    }
+
+    protected void fetchNext() {
+        try {
+            String lastId = lastSuccessNext != null ? lastSuccessNext.getId().getBase58String() : null;
+            LOGGER.debug("Dynamic load for remaining transactions: address={} page_size={} after_tx={}",
+                    address, pageSize, lastId);
+            List<? extends Transaction> txs = txSupplier.load(address, pageSize, lastId);
+            LOGGER.debug("Dynamic load for remaining transactions: loaded={}", txs.size());
+            dataIt = txs.iterator();
+            dataSize = txs.size();
+            hasNext = dataIt.hasNext();
+        } catch (IOException ex) {
+            throw new WrappedIOException(ex);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    @Override
+    public Transaction next() {
+        Transaction next;
+        if (hasNext) {
+            next = dataIt.next();
+            lastSuccessNext = next;
+            hasNext = dataIt.hasNext();
+            if (!hasNext
+                    && dataSize >= pageSize) { // condition to avoid addition request
+                fetchNext();
+            }
+            return next;
+        } else {
+            throw new NoSuchElementException("No more results");
+        }
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    public interface TransactionsLazyLoader<T> {
+        T load(String address, int limit, String after) throws IOException;
+    }
+
+    static class WrappedIOException extends RuntimeException {
+        private IOException ioEx;
+
+        public WrappedIOException(IOException ioEx) {
+            this.ioEx = ioEx;
+        }
+
+        public IOException unwrap() {
+            return ioEx;
+        }
+    }
+}

--- a/src/main/java/com/wavesplatform/wavesj/ApplicationStatus.java
+++ b/src/main/java/com/wavesplatform/wavesj/ApplicationStatus.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum ApplicationStatus {
 
-    @JsonProperty("succeed")
-    SUCCEED,
+    @JsonProperty("succeeded")
+    SUCCEEDED,
     @JsonProperty("script_execution_failed")
-    SCRIPT_EXECUTION_FAILED
+    SCRIPT_EXECUTION_FAILED,
+    @JsonProperty("unknown")
+    UNKNOWN
 
 }

--- a/src/main/java/com/wavesplatform/wavesj/ApplicationStatus.java
+++ b/src/main/java/com/wavesplatform/wavesj/ApplicationStatus.java
@@ -1,0 +1,12 @@
+package com.wavesplatform.wavesj;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ApplicationStatus {
+
+    @JsonProperty("succeed")
+    SUCCEED,
+    @JsonProperty("script_execution_failed")
+    SCRIPT_EXECUTION_FAILED
+
+}

--- a/src/main/java/com/wavesplatform/wavesj/AssetDistribution.java
+++ b/src/main/java/com/wavesplatform/wavesj/AssetDistribution.java
@@ -2,11 +2,8 @@ package com.wavesplatform.wavesj;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 
 import java.util.Map;
-
-import static com.wavesplatform.wavesj.Asset.normalize;
 
 public class AssetDistribution {
     public final String lastItem;

--- a/src/main/java/com/wavesplatform/wavesj/DataEntry.java
+++ b/src/main/java/com/wavesplatform/wavesj/DataEntry.java
@@ -15,7 +15,7 @@ import java.nio.ByteBuffer;
 
 import static com.wavesplatform.wavesj.ByteUtils.UTF8;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true, defaultImpl = DataEntry.DeleteEntry.class)
 @JsonTypeIdResolver(DataEntryTypeResolver.class)
 public abstract class DataEntry<T> {
     private final static byte INTEGER = 0;
@@ -30,7 +30,7 @@ public abstract class DataEntry<T> {
 
     private DataEntry(String key, String type, T value) {
         this.key = key;
-        this.type = type;
+        this.type = type == null ? "delete" : type;
         this.value = value;
     }
 
@@ -134,6 +134,13 @@ public abstract class DataEntry<T> {
         public void write(ByteBuffer buf) {
             super.write(buf);
             buf.put(STRING).putShort((short) bytes.length).put(bytes);
+        }
+    }
+
+    public static class DeleteEntry extends DataEntry<Void> {
+        @JsonCreator
+        public DeleteEntry(@JsonProperty("key") String key) {
+            super(key, null, null);
         }
     }
 

--- a/src/main/java/com/wavesplatform/wavesj/DataEntryTypeResolver.java
+++ b/src/main/java/com/wavesplatform/wavesj/DataEntryTypeResolver.java
@@ -27,7 +27,9 @@ public class DataEntryTypeResolver extends TypeIdResolverBase {
     public JavaType typeFromId(DatabindContext context, String id) throws IOException {
         Class t = null;
 
-        if (id.equals("integer")) {
+        if (id == null || id.equals("delete")) {
+            t = DataEntry.DeleteEntry.class;
+        } else if (id.equals("integer")) {
             t = DataEntry.LongEntry.class;
         } else if (id.equals("boolean")) {
             t = DataEntry.BooleanEntry.class;

--- a/src/main/java/com/wavesplatform/wavesj/Node.java
+++ b/src/main/java/com/wavesplatform/wavesj/Node.java
@@ -267,7 +267,7 @@ public class Node {
      * @return iterator which can throw {@link AllTxIterator.WrappedIOException}
      * @throws IOException in case of any network failures
      */
-    public Iterator<TransactionStCh> getAllAddressStateChanges(String address, int pageSize) throws IOException {
+    public Iterable<TransactionStCh> getAllAddressStateChanges(String address, int pageSize) throws IOException {
         try {
             return new AllTxIterator<TransactionStCh>(address, pageSize, new TransactionsLazyLoader<List<TransactionStCh>>() {
                 @Override

--- a/src/main/java/com/wavesplatform/wavesj/Transaction.java
+++ b/src/main/java/com/wavesplatform/wavesj/Transaction.java
@@ -21,13 +21,13 @@ public interface Transaction extends ApiJson, Signable {
      * Can be obtained ONLY during deserialization
      * @return transaction's height if available or 0
      */
-    public int getHeight();
+    int getHeight();
 
     /**
      * Can be obtained ONLY during deserialization
-     * @return transaction's status if available or SUCCEED
+     * @return transaction's status if available or UNKNOWN
      */
-    public ApplicationStatus getApplicationStatus();
+    ApplicationStatus getApplicationStatus();
 
     PublicKeyAccount getSenderPublicKey();
 

--- a/src/main/java/com/wavesplatform/wavesj/Transaction.java
+++ b/src/main/java/com/wavesplatform/wavesj/Transaction.java
@@ -28,4 +28,6 @@ public interface Transaction extends ApiJson, Signable {
     byte getType();
 
     byte getVersion();
+
+    boolean isStateChangesSupported();
 }

--- a/src/main/java/com/wavesplatform/wavesj/Transaction.java
+++ b/src/main/java/com/wavesplatform/wavesj/Transaction.java
@@ -23,6 +23,12 @@ public interface Transaction extends ApiJson, Signable {
      */
     public int getHeight();
 
+    /**
+     * Can be obtained ONLY during deserialization
+     * @return transaction's status if available or SUCCEED
+     */
+    public ApplicationStatus getApplicationStatus();
+
     PublicKeyAccount getSenderPublicKey();
 
     byte getType();

--- a/src/main/java/com/wavesplatform/wavesj/TransactionStCh.java
+++ b/src/main/java/com/wavesplatform/wavesj/TransactionStCh.java
@@ -1,0 +1,10 @@
+package com.wavesplatform.wavesj;
+
+import com.wavesplatform.wavesj.transactions.StateChanges;
+
+/**
+ * Interface to represent transaction types which support and track state changes
+ */
+public interface TransactionStCh extends Transaction {
+    StateChanges getStateChanges();
+}

--- a/src/main/java/com/wavesplatform/wavesj/json/WavesModule.java
+++ b/src/main/java/com/wavesplatform/wavesj/json/WavesModule.java
@@ -13,7 +13,8 @@ public class WavesModule extends SimpleModule {
         addDeserializer(ByteString.class, new ByteStringDeser());
         addDeserializer(Alias.class, new AliasDeser(chainId));
         addDeserializer(Order.Status.class, new OrderStatusDeser());
-        addDeserializer(Transaction.class, new TransactionDeserializer(objectMapper));
+        addDeserializer(Transaction.class, new TransactionDeserializer<Transaction>(objectMapper, Transaction.class));
+        addDeserializer(TransactionStCh.class, new TransactionDeserializer<TransactionStCh>(objectMapper, TransactionStCh.class));
         addDeserializer(Order.class, new OrderDeserializer(objectMapper));
 
         addSerializer(PublicKeyAccount.class, new PublicKeyAccountSer());

--- a/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionDeserializer.java
+++ b/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionDeserializer.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 
 public class TransactionDeserializer extends StdDeserializer<Transaction> {
 
-    private WavesJsonMapper objectMapper;
+    protected WavesJsonMapper objectMapper;
 
     public TransactionDeserializer(WavesJsonMapper objectMapper) {
         super(Transaction.class);
@@ -42,7 +42,7 @@ public class TransactionDeserializer extends StdDeserializer<Transaction> {
         return objectMapper.treeToValue(treeNode, t);
     }
 
-    private Class<? extends Transaction> getType(int type, int version, boolean debugAvailable) {
+    protected Class<? extends Transaction> getType(int type, int version, boolean debugAvailable) {
         Class<? extends Transaction> t = null;
         switch (type) {
             case AliasTransaction.ALIAS:

--- a/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionDeserializer.java
+++ b/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionDeserializer.java
@@ -12,17 +12,17 @@ import com.wavesplatform.wavesj.transactions.*;
 
 import java.io.IOException;
 
-public class TransactionDeserializer extends StdDeserializer<Transaction> {
+public class TransactionDeserializer<T extends Transaction> extends StdDeserializer<T> {
 
     protected WavesJsonMapper objectMapper;
 
-    public TransactionDeserializer(WavesJsonMapper objectMapper) {
-        super(Transaction.class);
+    public TransactionDeserializer(WavesJsonMapper objectMapper, Class<T> clazz) {
+        super(clazz);
         this.objectMapper = objectMapper;
     }
 
     @Override
-    public Transaction deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+    public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         TreeNode treeNode = jsonParser.getCodec().readTree(jsonParser);
         int type = objectMapper.treeToValue(treeNode.get("type"), Integer.class);
         int version = objectMapper.treeToValue(treeNode.get("version"), Integer.class);
@@ -37,12 +37,12 @@ public class TransactionDeserializer extends StdDeserializer<Transaction> {
         TreeNode stateChangesNode = treeNode.path("stateChanges");
         boolean debugAvailable = stateChangesNode != null && stateChangesNode.isObject();
 
-        Class<? extends Transaction> t = getType(type, version, debugAvailable);
+        Class<? extends T> t = getType(type, version, debugAvailable);
 
         return objectMapper.treeToValue(treeNode, t);
     }
 
-    protected Class<? extends Transaction> getType(int type, int version, boolean debugAvailable) {
+    protected Class<? extends T> getType(int type, int version, boolean debugAvailable) {
         Class<? extends Transaction> t = null;
         switch (type) {
             case AliasTransaction.ALIAS:
@@ -150,6 +150,9 @@ public class TransactionDeserializer extends StdDeserializer<Transaction> {
             default:
                 t = UnknownTransaction.class;
         }
-        return t;
+
+        @SuppressWarnings("unchecked")
+        Class<? extends T> tt = (Class<? extends T>) t;
+        return tt;
     }
 }

--- a/src/main/java/com/wavesplatform/wavesj/protobuf/PBTransactions.java
+++ b/src/main/java/com/wavesplatform/wavesj/protobuf/PBTransactions.java
@@ -86,10 +86,10 @@ public class PBTransactions {
             }
         } else if (tx.hasSetAssetScript()) {
             final TransactionOuterClass.SetAssetScriptTransactionData sas = tx.getSetAssetScript();
-            return new SetAssetScriptTransaction(senderPublicKey, (byte) tx.getChainId(), toVanillaAssetId(sas.getAssetId()), Base58.encode(sas.getScript().toByteArray()), feeAmount, timestamp, proofs);
+            return new SetAssetScriptTransaction(senderPublicKey, (byte) tx.getChainId(), toVanillaAssetId(sas.getAssetId()), Base64.encode(sas.getScript().toByteArray()), feeAmount, timestamp, proofs);
         } else if (tx.hasSetScript()) {
             final TransactionOuterClass.SetScriptTransactionData setScript = tx.getSetScript();
-            return new SetScriptTransaction(senderPublicKey, Base58.encode(setScript.getScript().toByteArray()), (byte) tx.getChainId(), feeAmount, timestamp, proofs);
+            return new SetScriptTransaction(senderPublicKey, Base64.encode(setScript.getScript().toByteArray()), (byte) tx.getChainId(), feeAmount, timestamp, proofs);
         } else if (tx.hasTransfer()) {
             final TransactionOuterClass.TransferTransactionData transfer = tx.getTransfer();
             switch (tx.getVersion()) {

--- a/src/main/java/com/wavesplatform/wavesj/protobuf/PBTransactions.java
+++ b/src/main/java/com/wavesplatform/wavesj/protobuf/PBTransactions.java
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString;
 import com.wavesplatform.protobuf.AmountOuterClass;
 import com.wavesplatform.protobuf.order.OrderOuterClass;
 import com.wavesplatform.protobuf.transaction.RecipientOuterClass;
-import com.wavesplatform.protobuf.transaction.ScriptOuterClass;
 import com.wavesplatform.protobuf.transaction.TransactionOuterClass;
 import com.wavesplatform.wavesj.*;
 import com.wavesplatform.wavesj.matcher.Order;
@@ -71,10 +70,10 @@ public class PBTransactions {
             final TransactionOuterClass.IssueTransactionData issue = tx.getIssue();
             switch (tx.getVersion()) {
                 case Transaction.V1:
-                    return new IssueTransactionV1(senderPublicKey, new String(issue.getName().toByteArray()), new String(issue.getDescription().toByteArray()), issue.getAmount(), (byte) issue.getDecimals(), issue.getReissuable(), feeAmount, timestamp, signature);
+                    return new IssueTransactionV1(senderPublicKey, issue.getName(), issue.getDescription(), issue.getAmount(), (byte) issue.getDecimals(), issue.getReissuable(), feeAmount, timestamp, signature);
 
                 case Transaction.V2:
-                    return new IssueTransactionV2(senderPublicKey, (byte) tx.getChainId(), new String(issue.getName().toByteArray()), new String(issue.getDescription().toByteArray()), issue.getAmount(), (byte) issue.getDecimals(), issue.getReissuable(), Base58.encode(issue.getScript().getBytes().toByteArray()), feeAmount, timestamp, proofs);
+                    return new IssueTransactionV2(senderPublicKey, (byte) tx.getChainId(), issue.getName(), issue.getDescription(), issue.getAmount(), (byte) issue.getDecimals(), issue.getReissuable(), Base64.encode(issue.getScript().toByteArray()), feeAmount, timestamp, proofs);
             }
         } else if (tx.hasReissue()) {
             final TransactionOuterClass.ReissueTransactionData reissue = tx.getReissue();
@@ -87,10 +86,10 @@ public class PBTransactions {
             }
         } else if (tx.hasSetAssetScript()) {
             final TransactionOuterClass.SetAssetScriptTransactionData sas = tx.getSetAssetScript();
-            return new SetAssetScriptTransaction(senderPublicKey, (byte) tx.getChainId(), toVanillaAssetId(sas.getAssetId()), Base58.encode(sas.getScript().getBytes().toByteArray()), feeAmount, timestamp, proofs);
+            return new SetAssetScriptTransaction(senderPublicKey, (byte) tx.getChainId(), toVanillaAssetId(sas.getAssetId()), Base58.encode(sas.getScript().toByteArray()), feeAmount, timestamp, proofs);
         } else if (tx.hasSetScript()) {
             final TransactionOuterClass.SetScriptTransactionData setScript = tx.getSetScript();
-            return new SetScriptTransaction(senderPublicKey, Base58.encode(setScript.getScript().getBytes().toByteArray()), (byte) tx.getChainId(), feeAmount, timestamp, proofs);
+            return new SetScriptTransaction(senderPublicKey, Base58.encode(setScript.getScript().toByteArray()), (byte) tx.getChainId(), feeAmount, timestamp, proofs);
         } else if (tx.hasTransfer()) {
             final TransactionOuterClass.TransferTransactionData transfer = tx.getTransfer();
             switch (tx.getVersion()) {
@@ -122,7 +121,7 @@ public class PBTransactions {
             final TransactionOuterClass.MassTransferTransactionData massTransfer = tx.getMassTransfer();
             final List<Transfer> transfers = new ArrayList<Transfer>(massTransfer.getTransfersList().size());
             for (TransactionOuterClass.MassTransferTransactionData.Transfer transfer : massTransfer.getTransfersList()) {
-                final Transfer transfer1 = new Transfer(toRecipientString(transfer.getAddress(), (byte) tx.getChainId()), transfer.getAmount());
+                final Transfer transfer1 = new Transfer(toRecipientString(transfer.getRecipient(), (byte) tx.getChainId()), transfer.getAmount());
                 transfers.add(transfer1);
             }
             return new MassTransferTransaction(senderPublicKey, toVanillaAssetId(massTransfer.getAssetId()), Collections.unmodifiableList(transfers), feeAmount, toVanillaByteString(massTransfer.getAttachment()), timestamp, proofs);
@@ -145,15 +144,15 @@ public class PBTransactions {
 
             ByteString script = ByteString.EMPTY;
             if (issue instanceof IssueTransactionV2)
-                script = ByteString.copyFrom(Base58.decode(((IssueTransactionV2) issue).getScript()));
+                script = ByteString.copyFrom(Base64.decode(((IssueTransactionV2) issue).getScript()));
 
             final TransactionOuterClass.IssueTransactionData data = TransactionOuterClass.IssueTransactionData.newBuilder()
                     .setAmount(issue.getQuantity())
                     .setDecimals(issue.getDecimals())
-                    .setName(ByteString.copyFrom(issue.getName().getBytes()))
-                    .setDescription(ByteString.copyFrom(issue.getDescription().getBytes()))
+                    .setName(issue.getName())
+                    .setDescription(issue.getDescription())
                     .setReissuable(issue.isReissuable())
-                    .setScript(ScriptOuterClass.Script.newBuilder().setBytes(script))
+                    .setScript(script)
                     .build();
             base.setIssue(data);
         } else if (tx instanceof ReissueTransaction) {
@@ -172,7 +171,7 @@ public class PBTransactions {
         } else if (tx instanceof SetScriptTransaction) {
             final SetScriptTransaction setScript = (SetScriptTransaction) tx;
             final TransactionOuterClass.SetScriptTransactionData data = TransactionOuterClass.SetScriptTransactionData.newBuilder()
-                    .setScript(ScriptOuterClass.Script.newBuilder().setBytes(ByteString.copyFrom(Base58.decode(setScript.getScript()))).build())
+                    .setScript(ByteString.copyFrom(Base64.decode(setScript.getScript())))
                     .build();
             base.setSetScript(data);
         } else if (tx instanceof SetAssetScriptTransaction) {
@@ -180,7 +179,7 @@ public class PBTransactions {
             final TransactionOuterClass.SetAssetScriptTransactionData data = TransactionOuterClass.SetAssetScriptTransactionData
                     .newBuilder()
                     .setAssetId(assetIdToBytes(sas.getAssetId()))
-                    .setScript(ScriptOuterClass.Script.newBuilder().setBytes(ByteString.copyFrom(Base58.decode(sas.getScript()))).build())
+                    .setScript(ByteString.copyFrom(Base64.decode(sas.getScript())))
                     .build();
             base.setSetAssetScript(data);
         } else if (tx instanceof DataTransaction) {
@@ -200,7 +199,7 @@ public class PBTransactions {
             final List<TransactionOuterClass.MassTransferTransactionData.Transfer> transfers = new ArrayList<TransactionOuterClass.MassTransferTransactionData.Transfer>(mtt.getTransfers().size());
             for (Transfer transfer : mtt.getTransfers()) {
                 TransactionOuterClass.MassTransferTransactionData.Transfer transfer1 = TransactionOuterClass.MassTransferTransactionData.Transfer.newBuilder()
-                        .setAddress(toPBRecipient(transfer.getRecipient()))
+                        .setRecipient(toPBRecipient(transfer.getRecipient()))
                         .setAmount(transfer.getAmount()).build();
                 transfers.add(transfer1);
             }
@@ -235,8 +234,8 @@ public class PBTransactions {
                     .setAmount(exchange.getAmount())
                     .setBuyMatcherFee(exchange.getBuyMatcherFee())
                     .setSellMatcherFee(exchange.getSellMatcherFee())
-                    .setOrders(0, toPBOrder(exchange.getOrder1()))
-                    .setOrders(1, toPBOrder(exchange.getOrder2()))
+                    .addOrders(toPBOrder(exchange.getOrder1()))
+                    .addOrders(toPBOrder(exchange.getOrder2()))
                     .build();
             base.setExchange(data);
         } else if (tx instanceof InvokeScriptTransaction) {
@@ -357,11 +356,11 @@ public class PBTransactions {
         switch (recipient.getRecipientCase()) {
             case ALIAS:
                 return recipient.getAlias();
-            case ADDRESS:
-                final ByteBuffer withoutChecksum = ByteBuffer.allocate(2 + recipient.getAddress().size())
+            case PUBLIC_KEY_HASH:
+                final ByteBuffer withoutChecksum = ByteBuffer.allocate(2 + recipient.getPublicKeyHash().size())
                         .put((byte) 1)
                         .put(chainId)
-                        .put(recipient.getAddress().toByteArray());
+                        .put(recipient.getPublicKeyHash().toByteArray());
                 withoutChecksum.flip();
                 final byte[] checksum = Hash.secureHash(withoutChecksum.array(), 0, withoutChecksum.capacity());
 
@@ -381,8 +380,8 @@ public class PBTransactions {
             final byte[] sourceAddr = Base58.decode(recipient);
             assert sourceAddr.length == 20;
 
-            final byte[] addr = Arrays.copyOfRange(sourceAddr, 2, sourceAddr.length - 4);
-            return RecipientOuterClass.Recipient.newBuilder().setAddress(ByteString.copyFrom(addr)).build();
+            final byte[] pubKeyHash = Arrays.copyOfRange(sourceAddr, 2, sourceAddr.length - 4);
+            return RecipientOuterClass.Recipient.newBuilder().setPublicKeyHash(ByteString.copyFrom(pubKeyHash)).build();
         } catch (Throwable e) {
             return RecipientOuterClass.Recipient.newBuilder().setAlias(recipient).build();
         }

--- a/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransaction.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransaction.java
@@ -25,14 +25,14 @@ public class InvokeScriptTransaction extends TransactionWithProofs<InvokeScriptT
     private static final int MAX_TX_SIZE = 5 * KBYTE;
     private byte chainId;
     private PublicKeyAccount senderPublicKey;
-    private @JsonProperty("dApp")
-    String dApp;
+    private String dApp;
     private FunctionCall call;
-    private @JsonProperty("payment")
-    List<Payment> payments = new ArrayList<Payment>();
     private long fee;
     private String feeAssetId;
     private long timestamp;
+
+    @JsonProperty("payment")
+    private List<Payment> payments = new ArrayList<Payment>();
 
     @JsonCreator
     public InvokeScriptTransaction(@JsonProperty("chainId") byte chainId,

--- a/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionStCh.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionStCh.java
@@ -3,11 +3,8 @@ package com.wavesplatform.wavesj.transactions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wavesplatform.wavesj.ByteString;
-import com.wavesplatform.wavesj.DataEntry;
 import com.wavesplatform.wavesj.PublicKeyAccount;
-import com.wavesplatform.wavesj.Transfer;
 
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -37,42 +34,5 @@ public class InvokeScriptTransactionStCh extends InvokeScriptTransaction {
 
     public StateChanges getStateChanges() {
         return stateChanges;
-    }
-
-    public static class StateChanges {
-        private Collection<DataEntry<?>> data;
-        private Collection<OutTransfer> transfers;
-
-        @JsonCreator
-        StateChanges(@JsonProperty("data") Collection<DataEntry<?>> data,
-                     @JsonProperty("transfers") Collection<OutTransfer> transfers) {
-            this.data = data;
-            this.transfers = transfers;
-        }
-
-        public Collection<DataEntry<?>> getData() {
-            return data;
-        }
-
-        public Collection<OutTransfer> getTransfers() {
-            return transfers;
-        }
-    }
-
-    public static class OutTransfer extends Transfer {
-
-        private String assetId;
-
-        @JsonCreator
-        OutTransfer(@JsonProperty("address") String recipient,
-                    @JsonProperty("amount") long amount,
-                    @JsonProperty("asset") String assetId) {
-            super(recipient, amount);
-            this.assetId = assetId;
-        }
-
-        public String getAssetId() {
-            return assetId;
-        }
     }
 }

--- a/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionStCh.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionStCh.java
@@ -1,0 +1,78 @@
+package com.wavesplatform.wavesj.transactions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wavesplatform.wavesj.ByteString;
+import com.wavesplatform.wavesj.DataEntry;
+import com.wavesplatform.wavesj.PublicKeyAccount;
+import com.wavesplatform.wavesj.Transfer;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * InvokeScriptTransaction with information about state changes
+ */
+public class InvokeScriptTransactionStCh extends InvokeScriptTransaction {
+
+    private StateChanges stateChanges;
+
+    /**
+     * This class couldn't be used to post transaction to blockchain that why constructor is package-private
+     */
+    @JsonCreator
+    InvokeScriptTransactionStCh(@JsonProperty("chainId") byte chainId,
+                                @JsonProperty("senderPublicKey") PublicKeyAccount senderPublicKey,
+                                @JsonProperty("dApp") String dApp,
+                                @JsonProperty("call") FunctionCall call,
+                                @JsonProperty("payment") List<Payment> payments,
+                                @JsonProperty("fee") long fee,
+                                @JsonProperty("feeAssetId") String feeAssetId,
+                                @JsonProperty("timestamp") long timestamp,
+                                @JsonProperty("proofs") List<ByteString> proofs,
+                                @JsonProperty("stateChanges") StateChanges stateChanges) {
+        super(chainId, senderPublicKey, dApp, call, payments, fee, feeAssetId, timestamp, proofs);
+        this.stateChanges = stateChanges;
+    }
+
+    public StateChanges getStateChanges() {
+        return stateChanges;
+    }
+
+    public static class StateChanges {
+        private Collection<DataEntry<?>> data;
+        private Collection<OutTransfer> transfers;
+
+        @JsonCreator
+        StateChanges(@JsonProperty("data") Collection<DataEntry<?>> data,
+                     @JsonProperty("transfers") Collection<OutTransfer> transfers) {
+            this.data = data;
+            this.transfers = transfers;
+        }
+
+        public Collection<DataEntry<?>> getData() {
+            return data;
+        }
+
+        public Collection<OutTransfer> getTransfers() {
+            return transfers;
+        }
+    }
+
+    public static class OutTransfer extends Transfer {
+
+        private String assetId;
+
+        @JsonCreator
+        OutTransfer(@JsonProperty("address") String recipient,
+                    @JsonProperty("amount") long amount,
+                    @JsonProperty("asset") String assetId) {
+            super(recipient, amount);
+            this.assetId = assetId;
+        }
+
+        public String getAssetId() {
+            return assetId;
+        }
+    }
+}

--- a/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionStCh.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionStCh.java
@@ -32,7 +32,13 @@ public class InvokeScriptTransactionStCh extends InvokeScriptTransaction {
         this.stateChanges = stateChanges;
     }
 
+    @Override
     public StateChanges getStateChanges() {
         return stateChanges;
+    }
+
+    @Override
+    public boolean isStateChangesSupported() {
+        return true;
     }
 }

--- a/src/main/java/com/wavesplatform/wavesj/transactions/StateChanges.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/StateChanges.java
@@ -6,6 +6,7 @@ import com.wavesplatform.wavesj.DataEntry;
 import com.wavesplatform.wavesj.Transfer;
 
 import java.util.Collection;
+import java.util.Collections;
 
 public class StateChanges {
     private Collection<DataEntry<?>> data;
@@ -14,14 +15,23 @@ public class StateChanges {
     @JsonCreator
     StateChanges(@JsonProperty("data") Collection<DataEntry<?>> data,
                  @JsonProperty("transfers") Collection<OutTransfer> transfers) {
-        this.data = data;
-        this.transfers = transfers;
+        this.data = data != null ? data : Collections.<DataEntry<?>>emptyList();
+        this.transfers = transfers != null ? transfers : Collections.<OutTransfer>emptyList();
     }
 
+    /**
+     * Returns collection of account's {@link DataEntry DataEntries} which were modified after applying transaction
+     * @return collection of {@link DataEntry DataEntries} or empty list
+     */
     public Collection<DataEntry<?>> getData() {
         return data;
     }
 
+    /**
+     * Returns collection of output transfers which were triggered after applying transaction. Currently such transfers
+     * are supported by ScriptInvocationTransaction only
+     * @return collection of transfers or empty list
+     */
     public Collection<OutTransfer> getTransfers() {
         return transfers;
     }

--- a/src/main/java/com/wavesplatform/wavesj/transactions/StateChanges.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/StateChanges.java
@@ -11,12 +11,27 @@ import java.util.Collections;
 public class StateChanges {
     private Collection<DataEntry<?>> data;
     private Collection<OutTransfer> transfers;
+    private Collection<IssueAction> issues;
+    private Collection<ReissueAction> reissues;
+    private Collection<BurnAction> burns;
+    private Collection<SponsorFeeAction> sponsorFees;
+    private Error error;
 
     @JsonCreator
     StateChanges(@JsonProperty("data") Collection<DataEntry<?>> data,
-                 @JsonProperty("transfers") Collection<OutTransfer> transfers) {
+                 @JsonProperty("transfers") Collection<OutTransfer> transfers,
+                 @JsonProperty("issues") Collection<IssueAction> issues,
+                 @JsonProperty("reissues") Collection<ReissueAction> reissues,
+                 @JsonProperty("burns") Collection<BurnAction> burns,
+                 @JsonProperty("sponsorFees") Collection<SponsorFeeAction> sponsorFees,
+                 @JsonProperty(value = "error", required = false) Error error) {
         this.data = data != null ? data : Collections.<DataEntry<?>>emptyList();
         this.transfers = transfers != null ? transfers : Collections.<OutTransfer>emptyList();
+        this.issues = issues != null ? issues : Collections.<IssueAction>emptyList();
+        this.reissues = reissues != null ? reissues : Collections.<ReissueAction>emptyList();
+        this.burns = burns != null ? burns : Collections.<BurnAction>emptyList();
+        this.sponsorFees = sponsorFees != null ? sponsorFees : Collections.<SponsorFeeAction>emptyList();
+        this.error = error != null ? error : new Error(0, "");
     }
 
     /**
@@ -36,6 +51,46 @@ public class StateChanges {
         return transfers;
     }
 
+    /**
+     * Returns collection of assets which were issued after applying transaction.
+     * @return collection of issued assets or empty list
+     */
+    public Collection<IssueAction> getIssues() {
+        return issues;
+    }
+
+    /**
+     * Returns collection of reissues of assets after applying transaction.
+     * @return collection of asset reissues or empty list
+     */
+    public Collection<ReissueAction> getReissues() {
+        return reissues;
+    }
+
+    /**
+     * Returns collection of burns of assets after applying transaction.
+     * @return collection of asset burns or empty list
+     */
+    public Collection<BurnAction> getBurns() {
+        return burns;
+    }
+
+    /**
+     * Returns collection of sponsorships of assets after applying transaction.
+     * @return collection of asset sponsorships or empty list
+     */
+    public Collection<SponsorFeeAction> getSponsorFees() {
+        return sponsorFees;
+    }
+
+    /**
+     * Returns error message if transaction is failed.
+     * @return error message
+     */
+    public Error getError() {
+        return error;
+    }
+
     public static class OutTransfer extends Transfer {
 
         private String assetId;
@@ -50,6 +105,155 @@ public class StateChanges {
 
         public String getAssetId() {
             return assetId;
+        }
+    }
+
+    public static class IssueAction {
+        private String assetId;
+        private String name;
+        private String description;
+        private long quantity;
+        private int decimals;
+        private boolean reissuable;
+        private String compiledScript;
+        private int nonce;
+
+        @JsonCreator
+        IssueAction(@JsonProperty("assetId") String assetId,
+                    @JsonProperty("name") String name,
+                    @JsonProperty("description") String description,
+                    @JsonProperty("quantity") long quantity,
+                    @JsonProperty("decimals") int decimals,
+                    @JsonProperty("isReissuable") boolean reissuable,
+                    @JsonProperty("compiledScript") String compiledScript,
+                    @JsonProperty("nonce") int nonce) {
+            this.assetId = assetId;
+            this.name = name;
+            this.description = description;
+            this.quantity = quantity;
+            this.decimals = decimals;
+            this.reissuable = reissuable;
+            this.compiledScript = compiledScript;
+            this.nonce = nonce;
+        }
+
+        public String getAssetId() {
+            return assetId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public long getQuantity() {
+            return quantity;
+        }
+
+        public int getDecimals() {
+            return decimals;
+        }
+
+        public boolean isReissuable() {
+            return reissuable;
+        }
+
+        public String getCompiledScript() {
+            return compiledScript;
+        }
+
+        public int getNonce() {
+            return nonce;
+        }
+    }
+
+    public static class ReissueAction {
+        private String assetId;
+        private long quantity;
+        private boolean reissuable;
+
+        @JsonCreator
+        ReissueAction(@JsonProperty("assetId") String assetId,
+                    @JsonProperty("quantity") long quantity,
+                    @JsonProperty("isReissuable") boolean reissuable) {
+            this.assetId = assetId;
+            this.quantity = quantity;
+            this.reissuable = reissuable;
+        }
+
+        public String getAssetId() {
+            return assetId;
+        }
+
+        public long getQuantity() {
+            return quantity;
+        }
+
+        public boolean isReissuable() {
+            return reissuable;
+        }
+    }
+
+    public static class BurnAction {
+        private String assetId;
+        private long amount;
+
+        @JsonCreator
+        BurnAction(@JsonProperty("assetId") String assetId,
+                    @JsonProperty("amount") long amount) {
+            this.assetId = assetId;
+            this.amount = amount;
+        }
+
+        public String getAssetId() {
+            return assetId;
+        }
+
+        public long getAmount() {
+            return amount;
+        }
+    }
+
+    public static class SponsorFeeAction {
+        private String assetId;
+        private long minSponsoredAssetFee;
+
+        @JsonCreator
+        SponsorFeeAction(@JsonProperty("assetId") String assetId,
+                    @JsonProperty("minSponsoredAssetFee") long minSponsoredAssetFee) {
+            this.assetId = assetId;
+            this.minSponsoredAssetFee = minSponsoredAssetFee;
+        }
+
+        public String getAssetId() {
+            return assetId;
+        }
+
+        public long getMinSponsoredAssetFee() {
+            return minSponsoredAssetFee;
+        }
+    }
+
+    public static class Error {
+        private int code;
+        private String text;
+
+        @JsonCreator
+        public Error(@JsonProperty("code") int code,
+                     @JsonProperty("text") String text) {
+            this.code = code;
+            this.text = text;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getText() {
+            return text;
         }
     }
 }

--- a/src/main/java/com/wavesplatform/wavesj/transactions/StateChanges.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/StateChanges.java
@@ -1,0 +1,45 @@
+package com.wavesplatform.wavesj.transactions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wavesplatform.wavesj.DataEntry;
+import com.wavesplatform.wavesj.Transfer;
+
+import java.util.Collection;
+
+public class StateChanges {
+    private Collection<DataEntry<?>> data;
+    private Collection<OutTransfer> transfers;
+
+    @JsonCreator
+    StateChanges(@JsonProperty("data") Collection<DataEntry<?>> data,
+                 @JsonProperty("transfers") Collection<OutTransfer> transfers) {
+        this.data = data;
+        this.transfers = transfers;
+    }
+
+    public Collection<DataEntry<?>> getData() {
+        return data;
+    }
+
+    public Collection<OutTransfer> getTransfers() {
+        return transfers;
+    }
+
+    public static class OutTransfer extends Transfer {
+
+        private String assetId;
+
+        @JsonCreator
+        OutTransfer(@JsonProperty("address") String recipient,
+                    @JsonProperty("amount") long amount,
+                    @JsonProperty("asset") String assetId) {
+            super(recipient, amount);
+            this.assetId = assetId;
+        }
+
+        public String getAssetId() {
+            return assetId;
+        }
+    }
+}

--- a/src/main/java/com/wavesplatform/wavesj/transactions/TransactionWithBytesHashId.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/TransactionWithBytesHashId.java
@@ -13,7 +13,7 @@ public abstract class TransactionWithBytesHashId implements TransactionStCh {
     @JsonProperty(value = "height", access = WRITE_ONLY)
     private int height;
 
-    @JsonProperty(value = "applicationStatus", defaultValue = "succeed", access = WRITE_ONLY)
+    @JsonProperty(value = "applicationStatus", defaultValue = "unknown", access = WRITE_ONLY)
     private ApplicationStatus applicationStatus;
 
     public ByteString getId() {

--- a/src/main/java/com/wavesplatform/wavesj/transactions/TransactionWithBytesHashId.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/TransactionWithBytesHashId.java
@@ -2,6 +2,7 @@ package com.wavesplatform.wavesj.transactions;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wavesplatform.wavesj.ApplicationStatus;
 import com.wavesplatform.wavesj.ByteString;
 import com.wavesplatform.wavesj.TransactionStCh;
 
@@ -12,12 +13,19 @@ public abstract class TransactionWithBytesHashId implements TransactionStCh {
     @JsonProperty(value = "height", access = WRITE_ONLY)
     private int height;
 
+    @JsonProperty(value = "applicationStatus", defaultValue = "succeed", access = WRITE_ONLY)
+    private ApplicationStatus applicationStatus;
+
     public ByteString getId() {
         return new ByteString(hash(getBodyBytes()));
     }
 
     public int getHeight() {
         return height;
+    }
+
+    public ApplicationStatus getApplicationStatus() {
+        return applicationStatus;
     }
 
     /**

--- a/src/main/java/com/wavesplatform/wavesj/transactions/TransactionWithBytesHashId.java
+++ b/src/main/java/com/wavesplatform/wavesj/transactions/TransactionWithBytesHashId.java
@@ -1,13 +1,14 @@
 package com.wavesplatform.wavesj.transactions;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wavesplatform.wavesj.ByteString;
-import com.wavesplatform.wavesj.Transaction;
+import com.wavesplatform.wavesj.TransactionStCh;
 
 import static com.fasterxml.jackson.annotation.JsonProperty.Access.WRITE_ONLY;
 import static com.wavesplatform.wavesj.ByteUtils.hash;
 
-public abstract class TransactionWithBytesHashId implements Transaction {
+public abstract class TransactionWithBytesHashId implements TransactionStCh {
     @JsonProperty(value = "height", access = WRITE_ONLY)
     private int height;
 
@@ -17,5 +18,23 @@ public abstract class TransactionWithBytesHashId implements Transaction {
 
     public int getHeight() {
         return height;
+    }
+
+    /**
+     * By default all transactions don't support this information
+     * @return whether transaction can provide information about state changes
+     */
+    @JsonIgnore
+    public boolean isStateChangesSupported() {
+        return false;
+    }
+
+    /**
+     *
+     * @return state changes which are done by transaction or <code>null</code>
+     */
+    @JsonIgnore
+    public StateChanges getStateChanges() {
+        return null;
     }
 }

--- a/src/test/java/com/wavesplatform/wavesj/AllTxIteratorITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/AllTxIteratorITest.java
@@ -12,10 +12,8 @@ public class AllTxIteratorITest extends BaseITest {
     @Test
     public void testDynamicLoad() {
         TestNode node = new TestNode();
-        Iterator<TransactionStCh> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 3);
         int txCount = 0;
-        while (it.hasNext()) {
-            it.next();
+        for (TransactionStCh tx: node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 3)) {
             ++txCount;
         }
         Assert.assertEquals(8, txCount);
@@ -29,7 +27,7 @@ public class AllTxIteratorITest extends BaseITest {
 
     private static class TestNode extends Node {
         @Override
-        public Iterator<TransactionStCh> getAllAddressStateChanges(String address, int pageSize) {
+        public Iterable<TransactionStCh> getAllAddressStateChanges(String address, int pageSize) {
             return new TestTxIterator(address, pageSize, new AllTxIterator.TransactionsLazyLoader<List<TransactionStCh>>() {
                 @Override
                 public List<TransactionStCh> load(String address, int limit, String after) throws IOException {

--- a/src/test/java/com/wavesplatform/wavesj/AllTxIteratorITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/AllTxIteratorITest.java
@@ -12,7 +12,7 @@ public class AllTxIteratorITest extends BaseITest {
     @Test
     public void testDynamicLoad() {
         TestNode node = new TestNode();
-        Iterator<Transaction> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 3);
+        Iterator<TransactionStCh> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 3);
         int txCount = 0;
         while (it.hasNext()) {
             it.next();
@@ -29,20 +29,20 @@ public class AllTxIteratorITest extends BaseITest {
 
     private static class TestNode extends Node {
         @Override
-        public Iterator<Transaction> getAllAddressStateChanges(String address, int pageSize) {
-            return new TestTxIterator(address, pageSize, new AllTxIterator.TransactionsLazyLoader<List<? extends Transaction>>() {
+        public Iterator<TransactionStCh> getAllAddressStateChanges(String address, int pageSize) {
+            return new TestTxIterator(address, pageSize, new AllTxIterator.TransactionsLazyLoader<List<TransactionStCh>>() {
                 @Override
-                public List<? extends Transaction> load(String address, int limit, String after) throws IOException {
-                    return TestNode.this.getAddressStateChanges(address, limit, after);
+                public List<TransactionStCh> load(String address, int limit, String after) throws IOException {
+                    return TestNode.this.getAddressStateChanges(address, limit, after) ;
                 }
             });
         }
     }
 
-    private static class TestTxIterator extends AllTxIterator {
+    private static class TestTxIterator extends AllTxIterator<TransactionStCh> {
         static int fetchesCount = 0;
 
-        TestTxIterator(String address, int pageSize, TransactionsLazyLoader<List<? extends Transaction>> txSupplier) {
+        public TestTxIterator(String address, int pageSize, TransactionsLazyLoader<List<TransactionStCh>> txSupplier) {
             super(address, pageSize, txSupplier);
         }
 

--- a/src/test/java/com/wavesplatform/wavesj/AllTxIteratorITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/AllTxIteratorITest.java
@@ -1,0 +1,55 @@
+package com.wavesplatform.wavesj;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+public class AllTxIteratorITest extends BaseITest {
+
+    @Test
+    public void testDynamicLoad() {
+        TestNode node = new TestNode();
+        Iterator<Transaction> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 3);
+        int txCount = 0;
+        while (it.hasNext()) {
+            it.next();
+            ++txCount;
+        }
+        Assert.assertEquals(8, txCount);
+        Assert.assertEquals(3, TestTxIterator.fetchesCount);
+    }
+
+    @Override
+    public void enableCleanUp() {
+        cleanUp = false;
+    }
+
+    private static class TestNode extends Node {
+        @Override
+        public Iterator<Transaction> getAllAddressStateChanges(String address, int pageSize) {
+            return new TestTxIterator(address, pageSize, new AllTxIterator.TransactionsLazyLoader<List<? extends Transaction>>() {
+                @Override
+                public List<? extends Transaction> load(String address, int limit, String after) throws IOException {
+                    return TestNode.this.getAddressStateChanges(address, limit, after);
+                }
+            });
+        }
+    }
+
+    private static class TestTxIterator extends AllTxIterator {
+        static int fetchesCount = 0;
+
+        TestTxIterator(String address, int pageSize, TransactionsLazyLoader<List<? extends Transaction>> txSupplier) {
+            super(address, pageSize, txSupplier);
+        }
+
+        @Override
+        protected void fetchNext() {
+            super.fetchNext();
+            ++fetchesCount;
+        }
+    }
+}

--- a/src/test/java/com/wavesplatform/wavesj/StateChangesITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/StateChangesITest.java
@@ -1,0 +1,57 @@
+package com.wavesplatform.wavesj;
+
+import com.wavesplatform.wavesj.transactions.InvokeScriptTransaction;
+import com.wavesplatform.wavesj.transactions.InvokeScriptTransactionStCh;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+public class StateChangesITest extends BaseITest {
+
+    @Test
+    public void invocationStateChanges() throws IOException {
+        Transaction tx = node.getStateChanges("FPUbH4VEGeao5oj4Ebq2znGc9sKvNaVc6H2vjPorr9bM");
+        Assert.assertEquals(InvokeScriptTransaction.CONTRACT_INVOKE, tx.getType());
+        InvokeScriptTransactionStCh inv = (InvokeScriptTransactionStCh) tx;
+        Assert.assertNotNull(inv.getStateChanges());
+        Assert.assertEquals(2, inv.getStateChanges().getData().size());
+        Assert.assertEquals(1, inv.getStateChanges().getTransfers().size());
+    }
+
+    @Test(expected = IOException.class)
+    public void failTransferStateChanges() throws IOException {
+        node.getStateChanges("CajkMdDA4A2e5QZkHF3vfRAPqPvhpKZ79H4STgKWpBVM");
+    }
+
+    @Test(expected = IOException.class)
+    public void failDataStateChanges() throws IOException {
+        node.getStateChanges("DDnQDdzGSLNwTRF4euxuCjoE2p87BF1pi66bop2MYjvW");
+    }
+
+    @Test
+    public void successAllAddressStateChanges() throws IOException {
+        Iterator<Transaction> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 5);
+        int count = 0;
+        while (it.hasNext()) {
+            Transaction tx = it.next();
+            count++;
+            if ("Gk9mBL4JNYAfBeW9HEmFaF6dK1WE8bi9NWhZ5Qn6wVTP".equals(tx.getId().getBase58String())) {
+                InvokeScriptTransactionStCh inv = (InvokeScriptTransactionStCh) tx;
+                Assert.assertNotNull(inv.getStateChanges());
+                Assert.assertEquals(1, inv.getStateChanges().getData().size());
+                Assert.assertEquals(0, inv.getStateChanges().getTransfers().size());
+                DataEntry<?> data1 = inv.getStateChanges().getData().iterator().next();
+                Assert.assertEquals("$voteFor", data1.getKey());
+                Assert.assertEquals(800L, ((Long) data1.getValue()).longValue());
+            }
+        }
+        Assert.assertEquals(8, count);
+    }
+
+    @Override
+    public void enableCleanUp() {
+        cleanUp = false;
+    }
+}

--- a/src/test/java/com/wavesplatform/wavesj/StateChangesITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/StateChangesITest.java
@@ -6,7 +6,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Iterator;
 
 public class StateChangesITest extends BaseITest {
 
@@ -32,17 +31,15 @@ public class StateChangesITest extends BaseITest {
 
     @Test
     public void successAllAddressStateChanges() throws IOException {
-        Iterator<TransactionStCh> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 5);
         int totalCount = 0;
         int stateChangesCount = 0;
-        while (it.hasNext()) {
-            TransactionStCh tx = it.next();
+        for (TransactionStCh tx : node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 5)) {
             totalCount++;
 
             if (tx.isStateChangesSupported()) {
                 stateChangesCount++;
                 Assert.assertNotNull(tx.getStateChanges());
-                Assert.assertEquals (1, tx.getStateChanges().getData().size());
+                Assert.assertEquals(1, tx.getStateChanges().getData().size());
                 Assert.assertEquals(0, tx.getStateChanges().getTransfers().size());
                 DataEntry<?> data1 = tx.getStateChanges().getData().iterator().next();
 

--- a/src/test/java/com/wavesplatform/wavesj/StateChangesITest.java
+++ b/src/test/java/com/wavesplatform/wavesj/StateChangesITest.java
@@ -32,22 +32,39 @@ public class StateChangesITest extends BaseITest {
 
     @Test
     public void successAllAddressStateChanges() throws IOException {
-        Iterator<Transaction> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 5);
-        int count = 0;
+        Iterator<TransactionStCh> it = node.getAllAddressStateChanges("3MpRhvzNbdQj2NErTX9w5642hyz7ht5aRza", 5);
+        int totalCount = 0;
+        int stateChangesCount = 0;
         while (it.hasNext()) {
-            Transaction tx = it.next();
-            count++;
-            if ("Gk9mBL4JNYAfBeW9HEmFaF6dK1WE8bi9NWhZ5Qn6wVTP".equals(tx.getId().getBase58String())) {
-                InvokeScriptTransactionStCh inv = (InvokeScriptTransactionStCh) tx;
-                Assert.assertNotNull(inv.getStateChanges());
-                Assert.assertEquals(1, inv.getStateChanges().getData().size());
-                Assert.assertEquals(0, inv.getStateChanges().getTransfers().size());
-                DataEntry<?> data1 = inv.getStateChanges().getData().iterator().next();
-                Assert.assertEquals("$voteFor", data1.getKey());
-                Assert.assertEquals(800L, ((Long) data1.getValue()).longValue());
+            TransactionStCh tx = it.next();
+            totalCount++;
+
+            if (tx.isStateChangesSupported()) {
+                stateChangesCount++;
+                Assert.assertNotNull(tx.getStateChanges());
+                Assert.assertEquals (1, tx.getStateChanges().getData().size());
+                Assert.assertEquals(0, tx.getStateChanges().getTransfers().size());
+                DataEntry<?> data1 = tx.getStateChanges().getData().iterator().next();
+
+                String txId = tx.getId().getBase58String();
+                if ("Gk9mBL4JNYAfBeW9HEmFaF6dK1WE8bi9NWhZ5Qn6wVTP".equals(txId)) {
+                    Assert.assertEquals("$voteFor", data1.getKey());
+                    assetLongDataValue(800L, data1);
+                } else if ("CTiJiM98Nh1QZ1CvaF68ZDEMpBLsWYN2WqxfFNqNVsa4".equals(txId)) {
+                    Assert.assertEquals("$voteAgainst", data1.getKey());
+                    assetLongDataValue(200L, data1);
+                } else if ("7qRC6UbpKsfxiPPQgBxYjHBXSFTABgbDksjtH2AujtGA".equals(txId)) {
+                    Assert.assertEquals("$voteAgainst", data1.getKey());
+                    assetLongDataValue(520L, data1);
+                }
             }
         }
-        Assert.assertEquals(8, count);
+        Assert.assertEquals(8, totalCount);
+        Assert.assertEquals(3, stateChangesCount);
+    }
+
+    private static void assetLongDataValue(long expected, DataEntry<?> actualData) {
+        Assert.assertEquals(expected, ((Long) actualData.getValue()).longValue());
     }
 
     @Override

--- a/src/test/java/com/wavesplatform/wavesj/json/deser/ExchangeTransactionDeserTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/deser/ExchangeTransactionDeserTest.java
@@ -66,6 +66,7 @@ public class ExchangeTransactionDeserTest extends TransactionDeserTest {
                         "\"sender\":\"3N22UCTvst8N1i1XDvGHzyqdgmZgwDKbp44\"," +
                         "\"senderPublicKey\":\"Fvk5DXmfyWVZqQVBowUBMwYtRAHDtdyZNNeRrwSjt6KP\"," +
                         "\"fee\":1," +
+                        "\"version\":1," +
                         "\"timestamp\":1526992336241," +
                         "\"signature\":" +
                         "\"5NxNhjMrrH5EWjSFnVnPbanpThic6fnNL48APVAkwq19y2FpQp4tNSqoAZgboC2ykUfqQs9suwBQj6wERmsWWNqa\"," +

--- a/src/test/java/com/wavesplatform/wavesj/json/deser/InvokeScriptTransactionDeserTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/deser/InvokeScriptTransactionDeserTest.java
@@ -1,5 +1,6 @@
 package com.wavesplatform.wavesj.json.deser;
 
+import com.wavesplatform.wavesj.transactions.InvokeScriptTransactionStCh;
 import com.wavesplatform.wavesj.transactions.InvokeScriptTransactionTestData;
 import com.wavesplatform.wavesj.transactions.InvokeScriptTransaction;
 import org.junit.Test;
@@ -32,4 +33,12 @@ public class InvokeScriptTransactionDeserTest extends TransactionDeserTest {
                 InvokeScriptTransaction.class);
     }
 
+    @Test
+    public void testDeserForTxWithStateChanges() throws IOException {
+        deserializationTest(
+                InvokeScriptTransactionTestData.txWithStateChangesJson(),
+                InvokeScriptTransactionTestData.txWithStateChanges(),
+                InvokeScriptTransactionStCh.class
+        );
+    }
 }

--- a/src/test/java/com/wavesplatform/wavesj/json/deser/InvokeScriptTransactionDeserTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/deser/InvokeScriptTransactionDeserTest.java
@@ -1,6 +1,6 @@
 package com.wavesplatform.wavesj.json.deser;
 
-import com.wavesplatform.wavesj.json.InvokeScriptTransactionTxTestData;
+import com.wavesplatform.wavesj.transactions.InvokeScriptTransactionTestData;
 import com.wavesplatform.wavesj.transactions.InvokeScriptTransaction;
 import org.junit.Test;
 
@@ -11,24 +11,24 @@ public class InvokeScriptTransactionDeserTest extends TransactionDeserTest {
     @Test
     public void V1DeserializeTest() throws IOException {
         deserializationTest(
-                InvokeScriptTransactionTxTestData.txFullJson(),
-                InvokeScriptTransactionTxTestData.txFull(),
+                InvokeScriptTransactionTestData.txFullJson(),
+                InvokeScriptTransactionTestData.txFull(),
                 InvokeScriptTransaction.class);
     }
 
     @Test
     public void testV1DeserTxNoFunctionCall() throws IOException {
         deserializationTest(
-                InvokeScriptTransactionTxTestData.txNoFunctionCallJson(),
-                InvokeScriptTransactionTxTestData.txNoFunctionCall(),
+                InvokeScriptTransactionTestData.txNoFunctionCallJson(),
+                InvokeScriptTransactionTestData.txNoFunctionCall(),
                 InvokeScriptTransaction.class);
     }
 
     @Test
     public void testV1DeserTxNoPayment() throws IOException {
         deserializationTest(
-                InvokeScriptTransactionTxTestData.txNoPaymentJson(),
-                InvokeScriptTransactionTxTestData.txNoPayment(),
+                InvokeScriptTransactionTestData.txNoPaymentJson(),
+                InvokeScriptTransactionTestData.txNoPayment(),
                 InvokeScriptTransaction.class);
     }
 

--- a/src/test/java/com/wavesplatform/wavesj/json/deser/TransactionDeserTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/deser/TransactionDeserTest.java
@@ -2,6 +2,7 @@ package com.wavesplatform.wavesj.json.deser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wavesplatform.wavesj.Transaction;
+import com.wavesplatform.wavesj.TransactionStCh;
 import com.wavesplatform.wavesj.json.WavesJsonMapper;
 
 import java.io.IOException;
@@ -13,10 +14,20 @@ public class TransactionDeserTest {
     ObjectMapper mapper = new WavesJsonMapper((byte) 'T');
 
     protected <T extends Transaction> T deserializationTest(String json, T tx, Class<T> txClass) throws IOException {
-        T deserialized = mapper.readValue(json, txClass);
-        assertEquals(deserialized, tx);
-        assertEquals(deserialized.getId(), tx.getId());
-        assertTrue("Height must be deserialized and greater than 0", deserialized.getHeight() > 0);
-        return deserialized;
+        T deser = mapper.readValue(json, txClass);
+
+        assertTxEquals(tx, deser);
+
+        // test deserialization for common interfaces
+        assertTxEquals(tx, mapper.readValue(json, Transaction.class));
+        assertTxEquals(tx, mapper.readValue(json, TransactionStCh.class));
+
+        return deser;
+    }
+
+    protected static void assertTxEquals(Transaction expected, Transaction actual) {
+        assertEquals(expected, actual);
+        assertEquals(expected.getId(), actual.getId());
+        assertTrue("Height must be deser and greater than 0", actual.getHeight() > 0);
     }
 }

--- a/src/test/java/com/wavesplatform/wavesj/json/ser/InvokeScriptTransactionSerTest.java
+++ b/src/test/java/com/wavesplatform/wavesj/json/ser/InvokeScriptTransactionSerTest.java
@@ -1,6 +1,6 @@
 package com.wavesplatform.wavesj.json.ser;
 
-import com.wavesplatform.wavesj.json.InvokeScriptTransactionTxTestData;
+import com.wavesplatform.wavesj.transactions.InvokeScriptTransactionTestData;
 import com.wavesplatform.wavesj.transactions.InvokeScriptTransaction;
 import org.junit.Test;
 
@@ -25,28 +25,28 @@ public class InvokeScriptTransactionSerTest extends TransactionSerTest {
     @Test
     public void testV1SerTxFull() throws IOException {
         serializationRoadtripTest(
-                InvokeScriptTransactionTxTestData.txFull(),
+                InvokeScriptTransactionTestData.txFull(),
                 InvokeScriptTransaction.class);
     }
 
     @Test
     public void testV1SerTxNoFunctionalCall() throws IOException {
         serializationRoadtripTest(
-                InvokeScriptTransactionTxTestData.txNoFunctionCall(),
+                InvokeScriptTransactionTestData.txNoFunctionCall(),
                 InvokeScriptTransaction.class);
     }
 
     @Test
     public void testV1SerTxNoPayment() throws IOException {
         serializationRoadtripTest(
-                InvokeScriptTransactionTxTestData.txNoPayment(),
+                InvokeScriptTransactionTestData.txNoPayment(),
                 InvokeScriptTransaction.class);
     }
 
     @Test
     public void testV1SerTxNoFunctionalCallAndPayment() throws IOException {
         serializationRoadtripTest(
-                InvokeScriptTransactionTxTestData.txNoFunctionCallAndPayment(),
+                InvokeScriptTransactionTestData.txNoFunctionCallAndPayment(),
                 InvokeScriptTransaction.class);
     }
 

--- a/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
+++ b/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
@@ -1,15 +1,14 @@
-package com.wavesplatform.wavesj.json;
+package com.wavesplatform.wavesj.transactions;
 
 import com.wavesplatform.wavesj.ByteString;
 import com.wavesplatform.wavesj.PublicKeyAccount;
 import com.wavesplatform.wavesj.json.ser.TransactionSerTest;
-import com.wavesplatform.wavesj.transactions.InvokeScriptTransaction;
 
 import static com.wavesplatform.wavesj.Asset.toWavelets;
 import static java.util.Collections.singletonList;
 
 
-public final class InvokeScriptTransactionTxTestData {
+public final class InvokeScriptTransactionTestData {
     private static final byte chainId = TransactionSerTest.chainId;
 
     public static final PublicKeyAccount SENDER_PUB =

--- a/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
+++ b/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
@@ -168,13 +168,13 @@ public final class InvokeScriptTransactionTestData {
                 null,
                 1561727253494L,
                 singletonList(new ByteString("4vUu8wkcvXvGX8S9RK2KQd6NzaQ8FqJgUK1zE9oMJxW3CEbT132si8FvcJ6UriYMKfSBkz8WPHnF6jLhNbYt1Ts2")),
-                new InvokeScriptTransactionStCh.StateChanges(
+                new StateChanges(
                         Arrays.<DataEntry<?>>asList(
                                 new DataEntry.StringEntry("CjX7LkS5G9Yq3XR2VPBkRY4Su8WbaR4KmjLqDh4Jz1VM",
                                         "03WON_03124_44144YmNQFhw3ZaT3PoS3pz8YQmwfzWsr5QJXBZh1EbVrZ_06562004_09380000000_014"),
                                 new DataEntry.LongEntry("$RESERVED_AMOUNT",
                                         0)),
-                        singletonList(new InvokeScriptTransactionStCh.OutTransfer(
+                        singletonList(new StateChanges.OutTransfer(
                                 "3N4yERKjhFqYXKV1D2RJLWCzmDqerCCvpNq",
                                 380000000L, null))
                 )

--- a/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
+++ b/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
@@ -1,8 +1,12 @@
 package com.wavesplatform.wavesj.transactions;
 
+import com.wavesplatform.wavesj.Base64;
 import com.wavesplatform.wavesj.ByteString;
+import com.wavesplatform.wavesj.DataEntry;
 import com.wavesplatform.wavesj.PublicKeyAccount;
 import com.wavesplatform.wavesj.json.ser.TransactionSerTest;
+
+import java.util.Arrays;
 
 import static com.wavesplatform.wavesj.Asset.toWavelets;
 import static java.util.Collections.singletonList;
@@ -149,5 +153,84 @@ public final class InvokeScriptTransactionTestData {
                 "\"type\":16," +
                 "\"version\":1," +
                 "\"height\":1234}";
+    }
+
+    public static InvokeScriptTransactionStCh txWithStateChanges() {
+        return new InvokeScriptTransactionStCh(
+                chainId,
+                new PublicKeyAccount("4f8jYJccCjarVgc8FHn5ms5YLkpi6PfHpxTnmjQZMkJk", chainId),
+                "3MqQ9ihYKGehfUnXYf5WmkYSZUD71ByeCQe",
+                new InvokeScriptTransaction.FunctionCall("withdraw")
+                        .addArg("CjX7LkS5G9Yq3XR2VPBkRY4Su8WbaR4KmjLqDh4Jz1VM")
+                        .addArg(new ByteString(Base64.decode("base64:gF+ENGvrNAadLgWxh/L1omQFi45C4JARpWd9QJYkk63Gszyq9nDfZqkMQ1xKyCNe/HNBlFyXKhy/tNtjNo5JUxTd0vvr8Dd6lEynFzsJDG3OSrWvSS3az59gWU0uyUXZtIiyibrIgW1KnTfLXfJtJ+BGEcrSn4/tjN6eSSzHR5KVuBVBugQKxgyettwcfo5N/EKnTtpFcTE5q9rzz/GLf84cRcUw5z5WhpUDmKGEy3ro6OoNYjiKb6r6L4tMauNJnVeMod2OqEMaYUSSaHEazx7ufGSse4M+quSza5Qxi+QcoTHPCRjsyO3p3qxsSiQjYFcmgSYMcf6zWSSVTwUjDQ=="))),
+                null,
+                500000,
+                null,
+                1561727253494L,
+                singletonList(new ByteString("4vUu8wkcvXvGX8S9RK2KQd6NzaQ8FqJgUK1zE9oMJxW3CEbT132si8FvcJ6UriYMKfSBkz8WPHnF6jLhNbYt1Ts2")),
+                new InvokeScriptTransactionStCh.StateChanges(
+                        Arrays.<DataEntry<?>>asList(
+                                new DataEntry.StringEntry("CjX7LkS5G9Yq3XR2VPBkRY4Su8WbaR4KmjLqDh4Jz1VM",
+                                        "03WON_03124_44144YmNQFhw3ZaT3PoS3pz8YQmwfzWsr5QJXBZh1EbVrZ_06562004_09380000000_014"),
+                                new DataEntry.LongEntry("$RESERVED_AMOUNT",
+                                        0)),
+                        singletonList(new InvokeScriptTransactionStCh.OutTransfer(
+                                "3N4yERKjhFqYXKV1D2RJLWCzmDqerCCvpNq",
+                                380000000L, null))
+                )
+        );
+    }
+
+    public static String txWithStateChangesJson() {
+        return "{\"chainId\":84,\n" +
+                "  \"senderPublicKey\": \"4f8jYJccCjarVgc8FHn5ms5YLkpi6PfHpxTnmjQZMkJk\",\n" +
+                "  \"fee\": 500000,\n" +
+                "  \"type\": 16,\n" +
+                "  \"version\": 1,\n" +
+                "  \"stateChanges\": {\n" +
+                "    \"data\": [\n" +
+                "      {\n" +
+                "        \"type\": \"string\",\n" +
+                "        \"value\": \"03WON_03124_44144YmNQFhw3ZaT3PoS3pz8YQmwfzWsr5QJXBZh1EbVrZ_06562004_09380000000_014\",\n" +
+                "        \"key\": \"CjX7LkS5G9Yq3XR2VPBkRY4Su8WbaR4KmjLqDh4Jz1VM\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"type\": \"integer\",\n" +
+                "        \"value\": 0,\n" +
+                "        \"key\": \"$RESERVED_AMOUNT\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"transfers\": [\n" +
+                "      {\n" +
+                "        \"address\": \"3N4yERKjhFqYXKV1D2RJLWCzmDqerCCvpNq\",\n" +
+                "        \"asset\": null,\n" +
+                "        \"amount\": 380000000\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"call\": {\n" +
+                "    \"function\": \"withdraw\",\n" +
+                "    \"args\": [\n" +
+                "      {\n" +
+                "        \"type\": \"string\",\n" +
+                "        \"value\": \"CjX7LkS5G9Yq3XR2VPBkRY4Su8WbaR4KmjLqDh4Jz1VM\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"type\": \"binary\",\n" +
+                "        \"value\": \"base64:gF+ENGvrNAadLgWxh/L1omQFi45C4JARpWd9QJYkk63Gszyq9nDfZqkMQ1xKyCNe/HNBlFyXKhy/tNtjNo5JUxTd0vvr8Dd6lEynFzsJDG3OSrWvSS3az59gWU0uyUXZtIiyibrIgW1KnTfLXfJtJ+BGEcrSn4/tjN6eSSzHR5KVuBVBugQKxgyettwcfo5N/EKnTtpFcTE5q9rzz/GLf84cRcUw5z5WhpUDmKGEy3ro6OoNYjiKb6r6L4tMauNJnVeMod2OqEMaYUSSaHEazx7ufGSse4M+quSza5Qxi+QcoTHPCRjsyO3p3qxsSiQjYFcmgSYMcf6zWSSVTwUjDQ==\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"dApp\": \"3MqQ9ihYKGehfUnXYf5WmkYSZUD71ByeCQe\",\n" +
+                "  \"sender\": \"3N4Aib5iubWiGMzdTh6wWiVDVbo32oeVUmH\",\n" +
+                "  \"feeAssetId\": null,\n" +
+                "  \"proofs\": [\n" +
+                "    \"4vUu8wkcvXvGX8S9RK2KQd6NzaQ8FqJgUK1zE9oMJxW3CEbT132si8FvcJ6UriYMKfSBkz8WPHnF6jLhNbYt1Ts2\"\n" +
+                "  ],\n" +
+                "  \"payment\": [],\n" +
+                "  \"id\": \"FPUbH4VEGeao5oj4Ebq2znGc9sKvNaVc6H2vjPorr9bM\",\n" +
+                "  \"timestamp\": 1561727253494,\n" +
+                "  \"height\": 562005\n" +
+                "}";
     }
 }

--- a/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
+++ b/src/test/java/com/wavesplatform/wavesj/transactions/InvokeScriptTransactionTestData.java
@@ -6,6 +6,7 @@ import com.wavesplatform.wavesj.DataEntry;
 import com.wavesplatform.wavesj.PublicKeyAccount;
 import com.wavesplatform.wavesj.json.ser.TransactionSerTest;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 import static com.wavesplatform.wavesj.Asset.toWavelets;
@@ -176,7 +177,12 @@ public final class InvokeScriptTransactionTestData {
                                         0)),
                         singletonList(new StateChanges.OutTransfer(
                                 "3N4yERKjhFqYXKV1D2RJLWCzmDqerCCvpNq",
-                                380000000L, null))
+                                380000000L, null)),
+                        new ArrayList<>(),
+                        new ArrayList<>(),
+                        new ArrayList<>(),
+                        new ArrayList<>(),
+                        new StateChanges.Error(0, "")
                 )
         );
     }


### PR DESCRIPTION
It is useful to have information about state changes which were done by transaction.
In scope of this commit the following was done:

1. new _InvokeScriptTransactionStCh_ with _stateChanges_ attribute was added. It was design to provide an additional information about Invocation transaction and couldn't be used to post invokes into blockchain. That why constructor was marked as package-private
2. new _AllTxIterator_ class to navigate over all account transactions. It has a generic semantic and can be used for other endpoints and transaction.
3. new methods to retrieve information about state changes were added into Node:
    - _Node#getStateChanges_
    - _Node#getAddressStateChanges_
    - _Node#getAllAddressStateChanges_