### PR TITLE
update to waves-transactions:1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <revision>1.0.0-SNAPSHOT</revision>
+        <revision>1.0.1-SNAPSHOT</revision>
     </properties>
 
     <name>WavesJ</name>
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>im.mak</groupId>
             <artifactId>waves-transactions</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.wavesplatform</groupId>


### PR DESCRIPTION
Support `"assetId": "WAVES"` as id of Waves token.