### PR TITLE
Enabled jacoco report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,20 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
reports (xml / csv / html ) available after test in default outputDir ( target/site/jacoco/ )

this is for #70 , after this i think something with https://github.com/codecov/example-java needs to be done to integrate this at the github side.