### PR TITLE
Transactions info by multiple IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <name>Peter Zhelezniakov</name>
             <email>peterz@rambler.ru</email>
             <organization>Waves</organization>
-            <organizationUrl>http://wavesplatform.com</organizationUrl>
+            <organizationUrl>https://waves.tech/</organizationUrl>
             <roles>
                 <role>Developer</role>
             </roles>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wavesplatform</groupId>
     <artifactId>wavesj</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wavesplatform</groupId>
     <artifactId>wavesj</artifactId>
-    <version>1.4.3</version>
+    <version>1.5.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/wavesplatform/wavesj/AssetDistribution.java
+++ b/src/main/java/com/wavesplatform/wavesj/AssetDistribution.java
@@ -6,6 +6,7 @@ import com.wavesplatform.transactions.account.Address;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 @SuppressWarnings("unused")
 public class AssetDistribution {
@@ -19,7 +20,7 @@ public class AssetDistribution {
                              @JsonProperty("lastItem") Address lastItem,
                              @JsonProperty("hasNext") boolean hasNext) {
         this.items = Common.notNull(items, "Items");
-        this.lastItem = Common.notNull(lastItem, "LastItem");
+        this.lastItem = lastItem;
         this.hasNext = hasNext;
     }
 
@@ -27,8 +28,11 @@ public class AssetDistribution {
         return items;
     }
 
-    public Address lastItem() {
-        return lastItem;
+    /**
+     * @return last item if there is at least one address, otherwise empty
+     */
+    public Optional<Address> lastItem() {
+        return Optional.ofNullable(lastItem);
     }
 
     public boolean hasNext() {

--- a/src/main/java/com/wavesplatform/wavesj/AssetDistribution.java
+++ b/src/main/java/com/wavesplatform/wavesj/AssetDistribution.java
@@ -6,7 +6,6 @@ import com.wavesplatform.transactions.account.Address;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 @SuppressWarnings("unused")
 public class AssetDistribution {
@@ -28,11 +27,8 @@ public class AssetDistribution {
         return items;
     }
 
-    /**
-     * @return last item if there is at least one address, otherwise empty
-     */
-    public Optional<Address> lastItem() {
-        return Optional.ofNullable(lastItem);
+    public Address lastItem() {
+        return lastItem;
     }
 
     public boolean hasNext() {

--- a/src/main/java/com/wavesplatform/wavesj/BlockHeaders.java
+++ b/src/main/java/com/wavesplatform/wavesj/BlockHeaders.java
@@ -69,7 +69,8 @@ public class BlockHeaders {
 
     @JsonProperty("nxt-consensus")
     private void nxtConsensus(Map<String, Object> nxtConsensus) {
-        this.baseTarget = (int) nxtConsensus.get("base-target");
+        Object baseTargetObj = nxtConsensus.get("base-target");
+        this.baseTarget = baseTargetObj instanceof Long ? (Long) baseTargetObj : (Integer) baseTargetObj;
         this.generationSignature = new Base58String((String) nxtConsensus.get("generation-signature"));
     }
 

--- a/src/main/java/com/wavesplatform/wavesj/Node.java
+++ b/src/main/java/com/wavesplatform/wavesj/Node.java
@@ -621,6 +621,14 @@ public class Node {
                 TypeRef.SCRIPT_INFO);
     }
 
+    public String decompileScript(Base64String compiledScript) throws IOException, NodeException {
+        return asJson(post("/utils/script/decompile")
+                        .addHeader("Content-Type", "application/json")
+                        .setEntity(new StringEntity(compiledScript.toString(), StandardCharsets.UTF_8)))
+                .get("script")
+                .asText();
+    }
+
     public String ethToWavesAsset(String asset) throws NodeException, IOException {
         return asType(
                 get("/eth/assets").addParameter("id", asset),

--- a/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionWithStatusDeser.java
+++ b/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionWithStatusDeser.java
@@ -20,7 +20,10 @@ public class TransactionWithStatusDeser extends JsonDeserializer<TransactionWith
 
         //transaction fields and info fields are on the same level
         Transaction tx = Transaction.fromJson(json.toString());
-        ApplicationStatus status = codec.treeToValue(json.get("applicationStatus"), ApplicationStatus.class);
+        ApplicationStatus status =
+                json.has("applicationStatus")
+                        ? codec.treeToValue(json.get("applicationStatus"), ApplicationStatus.class)
+                        : ApplicationStatus.SUCCEEDED;
 
         return new TransactionWithStatus(tx, status);
     }

--- a/src/test/java/node/AssetsTest.java
+++ b/src/test/java/node/AssetsTest.java
@@ -81,13 +81,13 @@ public class AssetsTest extends BaseTestWithNodeInDocker {
         AssetDistribution distributionPage1 =
                 node.getAssetDistribution(assetId, node.getHeight() - 1, 1000);
         AssetDistribution distributionPage2 =
-                node.getAssetDistribution(assetId, node.getHeight() - 1, 1000, distributionPage1.lastItem().get());
+                node.getAssetDistribution(assetId, node.getHeight() - 1, 1000, distributionPage1.lastItem());
 
         assertThat(distributionPage1.hasNext()).isTrue();
         assertThat(distributionPage2.hasNext()).isFalse();
 
-        assertThat(distributionPage1.items()).containsKey(distributionPage1.lastItem().get());
-        assertThat(distributionPage2.items()).containsKey(distributionPage2.lastItem().get());
+        assertThat(distributionPage1.items()).containsKey(distributionPage1.lastItem());
+        assertThat(distributionPage2.items()).containsKey(distributionPage2.lastItem());
 
         List<Transfer> items1 = new ArrayList<>();
         distributionPage1.items().forEach((k, v) -> items1.add(Transfer.to(k, v)));

--- a/src/test/java/node/AssetsTest.java
+++ b/src/test/java/node/AssetsTest.java
@@ -81,13 +81,13 @@ public class AssetsTest extends BaseTestWithNodeInDocker {
         AssetDistribution distributionPage1 =
                 node.getAssetDistribution(assetId, node.getHeight() - 1, 1000);
         AssetDistribution distributionPage2 =
-                node.getAssetDistribution(assetId, node.getHeight() - 1, 1000, distributionPage1.lastItem());
+                node.getAssetDistribution(assetId, node.getHeight() - 1, 1000, distributionPage1.lastItem().get());
 
         assertThat(distributionPage1.hasNext()).isTrue();
         assertThat(distributionPage2.hasNext()).isFalse();
 
-        assertThat(distributionPage1.items()).containsKey(distributionPage1.lastItem());
-        assertThat(distributionPage2.items()).containsKey(distributionPage2.lastItem());
+        assertThat(distributionPage1.items()).containsKey(distributionPage1.lastItem().get());
+        assertThat(distributionPage2.items()).containsKey(distributionPage2.lastItem().get());
 
         List<Transfer> items1 = new ArrayList<>();
         distributionPage1.items().forEach((k, v) -> items1.add(Transfer.to(k, v)));


### PR DESCRIPTION
Added:
* `getTransactionsInfo()` to request multiple transactions
* `decompileScript()`
* `waitForTransaction()` additional methods

Also fixed:
* missing `applicationStatus` for old transactions;
* `baseTarget`: it may be long (height `23873` in mainnet as example);
* field `lastItem` in asset disribution may be null if there's no asset holders, because its quantity is 0;
* outdated official website URL in pom.xml