### PR TITLE
Jackson core old version support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wavesplatform</groupId>
     <artifactId>wavesj</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionInfoDeser.java
+++ b/src/main/java/com/wavesplatform/wavesj/json/deser/TransactionInfoDeser.java
@@ -77,6 +77,7 @@ public class TransactionInfoDeser extends JsonDeserializer<TransactionInfo> {
     }
 
     private StateChanges stateChangesFromJson(ObjectCodec codec, JsonNode json) throws JsonProcessingException {
-        return json.get("payload") != null ? codec.treeToValue(json.get("payload").get("stateChanges"), StateChanges.class) : null;
+        JsonNode stateChanges = json.get("payload").get("stateChanges");
+        return stateChanges != null ? codec.treeToValue(stateChanges, StateChanges.class) : null;
     }
 }

--- a/src/test/java/node/transactions/EthereumTransactionIntegrationTest.java
+++ b/src/test/java/node/transactions/EthereumTransactionIntegrationTest.java
@@ -73,9 +73,9 @@ public class EthereumTransactionIntegrationTest extends BaseTestWithNodeInDocker
         String bobAddress = WavesEthConverter.ethToWavesAddress(bob.getAddress(), WavesConfig.chainId());
 
         AssetId assetId = createAsset(alice);
-        transferBalance(alice, new Address(bobAddress), Amount.of(1_00_000_000, assetId));
+        transferBalance(alice, new Address(bobAddress), Amount.of(100, assetId));
         broadcastScript(alice);
-        transferBalance(alice, new Address(bobAddress), Amount.of(1_00_000_000));
+        transferBalance(alice, new Address(bobAddress), Amount.of(3_00_000_000));
 
         ArrayList<Amount> payments = new ArrayList<>();
         payments.add(Amount.of(1, assetId));

--- a/src/test/java/node/transactions/EthereumTransactionIntegrationTest.java
+++ b/src/test/java/node/transactions/EthereumTransactionIntegrationTest.java
@@ -73,7 +73,7 @@ public class EthereumTransactionIntegrationTest extends BaseTestWithNodeInDocker
         String bobAddress = WavesEthConverter.ethToWavesAddress(bob.getAddress(), WavesConfig.chainId());
 
         AssetId assetId = createAsset(alice);
-        transferBalance(alice, new Address(bobAddress), Amount.of(100, assetId));
+        transferBalance(alice, new Address(bobAddress), Amount.of(1_00_000_000, assetId));
         broadcastScript(alice);
         transferBalance(alice, new Address(bobAddress), Amount.of(1_00_000_000));
 


### PR DESCRIPTION
 - fix mapper that throws NPE on old jackson core versions